### PR TITLE
Fixed comparison of integer expressions of different signedness

### DIFF
--- a/sciplot/plot.hpp
+++ b/sciplot/plot.hpp
@@ -273,7 +273,7 @@ auto plot::show() -> void
     const auto n = m_plotspecs.size();
 
     // Plot in the same figure all those given drawing specs
-    for(auto i = decltype(n){0}; i < n; ++i)
+    for(std::size_t i = 0; i < n; ++i)
         script << m_plotspecs[i] << (i < n - 1 ? ", " : "");
 
     // Add an empty line at the end
@@ -343,7 +343,7 @@ auto plot::save(std::string filename) -> void
     const auto n = m_plotspecs.size();
 
     // Plot in the same figure all those given drawing specs
-    for(auto i = decltype(n){0}; i < n; ++i)
+    for(std::size_t i = 0; i < n; ++i)
         script << m_plotspecs[i] << (i < n - 1 ? ", " : "");
 
     // Unset the output

--- a/sciplot/plot.hpp
+++ b/sciplot/plot.hpp
@@ -273,7 +273,7 @@ auto plot::show() -> void
     const auto n = m_plotspecs.size();
 
     // Plot in the same figure all those given drawing specs
-    for(auto i = 0; i < n; ++i)
+    for(auto i = decltype(n){0}; i < n; ++i)
         script << m_plotspecs[i] << (i < n - 1 ? ", " : "");
 
     // Add an empty line at the end
@@ -343,7 +343,7 @@ auto plot::save(std::string filename) -> void
     const auto n = m_plotspecs.size();
 
     // Plot in the same figure all those given drawing specs
-    for(auto i = 0; i < n; ++i)
+    for(auto i = decltype(n){0}; i < n; ++i)
         script << m_plotspecs[i] << (i < n - 1 ? ", " : "");
 
     // Unset the output

--- a/sciplot/util.hpp
+++ b/sciplot/util.hpp
@@ -129,7 +129,7 @@ template<typename... Args>
 auto write(std::ostream& out, const Args&... args) -> std::ostream&
 {
     const auto size = minsize(args...);
-    for(auto i = decltype(size){0}; i < size; ++i)
+    for(std::size_t i = 0; i < size; ++i)
         writeline(out, i, args...);
     return out;
 }

--- a/sciplot/util.hpp
+++ b/sciplot/util.hpp
@@ -129,7 +129,7 @@ template<typename... Args>
 auto write(std::ostream& out, const Args&... args) -> std::ostream&
 {
     const auto size = minsize(args...);
-    for(auto i = 0; i < size; ++i)
+    for(auto i = decltype(size){0}; i < size; ++i)
         writeline(out, i, args...);
     return out;
 }


### PR DESCRIPTION
When compiling with GCC 8.1.0 on Ubuntu 16.04 with `-Wsign-compare` and `-Werror` I get following compile error in edited lines:
```
Comparison of integer expressions of different signedness: 'int' and 'const long unsingned int'
```

Proposed fix solves that problem.