### PR TITLE
Rename style to plotstyle and fix tick label font settings

### DIFF
--- a/sciplot/default.hpp
+++ b/sciplot/default.hpp
@@ -42,7 +42,7 @@ const auto DEFAULT_FONTSIZE = 12;
 
 const auto DEFAULT_TEXTCOLOR = "#404040";
 
-const auto DEFAULT_LINESTYLE = style::lines;
+const auto DEFAULT_PLOTSTYLE = plotstyle::lines;
 const auto DEFAULT_LINEWIDTH = 2;
 
 const auto DEFAULT_BORDER_LINECOLOR = "#404040";

--- a/sciplot/enums.hpp
+++ b/sciplot/enums.hpp
@@ -31,7 +31,7 @@
 namespace sciplot {
 
 /// All gnuplot style options for plotting data
-enum class style
+enum class plotstyle
 {
     lines,
     points,
@@ -76,37 +76,37 @@ enum class ext
 namespace internal {
 
 /// Return a string for a given enum value of type `with`
-inline auto stylestr(style value) -> std::string
+inline auto plotstylestr(plotstyle value) -> std::string
 {
     switch(value) {
-    case style::lines: return "lines";
-    case style::points: return "points";
-    case style::linespoints: return "linespoints";
-    case style::impulses: return "impulses";
-    case style::dots: return "dots";
-    case style::steps: return "steps";
-    case style::fsteps: return "fsteps";
-    case style::histeps: return "histeps";
-    case style::errorbars: return "errorbars";
-    case style::labels: return "labels";
-    case style::xerrorbars: return "xerrorbars";
-    case style::yerrorbars: return "yerrorbars";
-    case style::xyerrorbars: return "xyerrorbars";
-    case style::errorlines: return "errorlines";
-    case style::xerrorlines: return "xerrorlines";
-    case style::yerrorlines: return "yerrorlines";
-    case style::xyerrorlines: return "xyerrorlines";
-    case style::boxes: return "boxes";
-    case style::histograms: return "histograms";
-    case style::filledcurves: return "filledcurves";
-    case style::boxerrorbars: return "boxerrorbars";
-    case style::boxxyerrorbars: return "boxxyerrorbars";
-    case style::financebars: return "financebars";
-    case style::candlesticks: return "candlesticks";
-    case style::vectors: return "vectors";
-    case style::image: return "image";
-    case style::rgbimage: return "rgbimage";
-    case style::pm3d: return "pm3d";
+    case plotstyle::lines: return "lines";
+    case plotstyle::points: return "points";
+    case plotstyle::linespoints: return "linespoints";
+    case plotstyle::impulses: return "impulses";
+    case plotstyle::dots: return "dots";
+    case plotstyle::steps: return "steps";
+    case plotstyle::fsteps: return "fsteps";
+    case plotstyle::histeps: return "histeps";
+    case plotstyle::errorbars: return "errorbars";
+    case plotstyle::labels: return "labels";
+    case plotstyle::xerrorbars: return "xerrorbars";
+    case plotstyle::yerrorbars: return "yerrorbars";
+    case plotstyle::xyerrorbars: return "xyerrorbars";
+    case plotstyle::errorlines: return "errorlines";
+    case plotstyle::xerrorlines: return "xerrorlines";
+    case plotstyle::yerrorlines: return "yerrorlines";
+    case plotstyle::xyerrorlines: return "xyerrorlines";
+    case plotstyle::boxes: return "boxes";
+    case plotstyle::histograms: return "histograms";
+    case plotstyle::filledcurves: return "filledcurves";
+    case plotstyle::boxerrorbars: return "boxerrorbars";
+    case plotstyle::boxxyerrorbars: return "boxxyerrorbars";
+    case plotstyle::financebars: return "financebars";
+    case plotstyle::candlesticks: return "candlesticks";
+    case plotstyle::vectors: return "vectors";
+    case plotstyle::image: return "image";
+    case plotstyle::rgbimage: return "rgbimage";
+    case plotstyle::pm3d: return "pm3d";
     default: return "lines";
     }
 }

--- a/sciplot/specs/plotspecs.hpp
+++ b/sciplot/specs/plotspecs.hpp
@@ -48,7 +48,7 @@ public:
     auto title(std::string value) -> plotspecs& { m_title = titlestr(value); return *this; }
 
     /// Set the format of the plot (lines, points, linespoints).
-    auto with(style value) -> plotspecs& { m_with = stylestr(value); return *this; }
+    auto with(plotstyle value) -> plotspecs& { m_with = plotstylestr(value); return *this; }
 
 private:
     /// The what to be plotted as a gnuplot formatted string (e.g., "sin(x)").
@@ -78,7 +78,7 @@ private:
 
 plotspecs::plotspecs(std::string what) : m_what(what)
 {
-    with(DEFAULT_LINESTYLE);
+    with(DEFAULT_PLOTSTYLE);
 }
 
 auto plotspecs::repr() const -> std::string

--- a/sciplot/specs/ticspecs.hpp
+++ b/sciplot/specs/ticspecs.hpp
@@ -97,7 +97,8 @@ auto ticspecs::repr() const -> std::string
 {
     std::stringstream ss;
     ss << "set tics " << m_mirror << " " << m_depth << " " << m_inout << " ";
-    ss << "scale " << m_scalemajor << "," << m_scaleminor;
+    ss << "scale " << m_scalemajor << "," << m_scaleminor << " ";
+    ss << textspecs<ticspecs>::repr();
     return ss.str();
 }
 


### PR DESCRIPTION
Bear with me, as I'm a GNUplot beginner...
* The enum name "style" is misleading imo. What it technically is, is the style for the whole plot (lines boxes, histogram). If I google "gnuplot plot style" the first link is [this](http://www.gnuplot.info/docs_4.2/node238.html). There are many more styles you can set, so I'd rename this to differentiate. An alternative name might be "WithStyle".
* The font setting for plot ticks were not used, as a superclass call was missing.