### PR TITLE
Remove temporary files to address issue #12

### DIFF
--- a/examples/example-multiplot.cpp
+++ b/examples/example-multiplot.cpp
@@ -49,6 +49,9 @@ int main(int argc, char** argv)
     mp.palette("dark2");
     mp.layout(2, 2);
 
+    // Fill up columns of the multiplot first and grow layout upwards (default is rowsfirst downwards)
+    mp.fillorder(fillordertype::columnsfirst).growdirection(growdirectiontype::upwards);
+
     // Add plots to multiplot
     mp.add(p0).add(p1).add(p2).add(p3);
 

--- a/sciplot/enums.hpp
+++ b/sciplot/enums.hpp
@@ -80,6 +80,20 @@ enum class boxwidthtype
     absolute
 };
 
+/// Multiplot layout grow direction
+enum class growdirectiontype
+{
+    downwards,
+    upwards
+};
+
+/// Multiplot layout fill order
+enum class fillordertype
+{
+    rowsfirst,
+    columnsfirst
+};
+
 /// All extension formats supported by sciplot when saving a plot to a file.
 enum class ext
 {
@@ -151,6 +165,28 @@ inline auto boxwidthtypestr(boxwidthtype value) -> std::string
         case boxwidthtype::relative: return "relative";
         case boxwidthtype::absolute: return "absolute";
         default: return "";
+    }
+}
+
+/// Return a string for a given enum value of type `fillorder`
+inline auto fillordertypestr(fillordertype value) -> std::string
+{
+    switch (value)
+    {
+        case fillordertype::rowsfirst: return "rowsfirst";
+        case fillordertype::columnsfirst: return "columnsfirst";
+        default: return "rowsfirst";
+    }
+}
+
+/// Return a string for a given enum value of type `growdirection`
+inline auto growdirectiontypestr(growdirectiontype value) -> std::string
+{
+    switch (value)
+    {
+        case growdirectiontype::downwards: return "downwards";
+        case growdirectiontype::upwards: return "upwards";
+        default: return "downwards";
     }
 }
 

--- a/sciplot/multiplot.hpp
+++ b/sciplot/multiplot.hpp
@@ -67,6 +67,12 @@ class multiplot
     /// Set the layout of the multiplot in x- and y-direction.
     auto layout(std::size_t rows, std::size_t columns) -> multiplot&;
 
+    /// Set order in which the layout will be filled.
+    auto fillorder(fillordertype value) -> multiplot&;
+
+    /// Set direction in which the layout will grow.
+    auto growdirection(growdirectiontype value) -> multiplot&;
+
     /// Set the title of the multiplot.
     auto title(const std::string& title) -> multiplot&;
 
@@ -118,6 +124,12 @@ class multiplot
     /// The number of columns in the multiplot layout
     std::size_t m_layoutcols = 0;
 
+    /// Order in which the layout will be filled
+    fillordertype m_fillorder = fillordertype::rowsfirst;
+
+    /// Direction in which the layout will grow
+    growdirectiontype m_growdirection = growdirectiontype::downwards;
+
     /// The title of the plot
     std::string m_title;
 
@@ -161,6 +173,18 @@ auto multiplot::layout(std::size_t rows, std::size_t columns) -> multiplot&
     return *this;
 }
 
+auto multiplot::fillorder(fillordertype value) -> multiplot&
+{
+    m_fillorder = value;
+    return *this;
+}
+
+auto multiplot::growdirection(growdirectiontype value) -> multiplot&
+{
+    m_growdirection = value;
+    return *this;
+}
+
 auto multiplot::title(const std::string& title) -> multiplot&
 {
     m_title = title;
@@ -193,7 +217,7 @@ auto multiplot::show() const -> void
     gnuplot::showterminalcmd(script);
 
     // Add multiplot commands
-    gnuplot::multiplotcmd(script, m_layoutrows, m_layoutcols, m_title);
+    gnuplot::multiplotcmd(script, m_layoutrows, m_layoutcols, m_fillorder, m_growdirection, m_title);
 
     // Add the plot commands
     for (const auto& p : m_plots)
@@ -242,7 +266,7 @@ auto multiplot::save(const std::string& filename) const -> void
     gnuplot::outputcmd(script, cleanedfilename);
 
     // Add multiplot commands
-    gnuplot::multiplotcmd(script, m_layoutrows, m_layoutcols, m_title);
+    gnuplot::multiplotcmd(script, m_layoutrows, m_layoutcols, m_fillorder, m_growdirection, m_title);
 
     // Add the plot commands
     for (const auto& p : m_plots)

--- a/sciplot/multiplot.hpp
+++ b/sciplot/multiplot.hpp
@@ -53,6 +53,10 @@ class multiplot
     /// Construct a default multiplot object
     multiplot();
 
+    /// Toggle automatic cleaning of temporary files (enabled by default). Pass false if you want to keep your script / data files.
+    /// Call cleanup() to remove those files manually.
+    auto autoclean(bool enable = true) -> void;
+
     /// Set the palette of colors for the plot.
     /// @param name Any palette name displayed in https://github.com/Gnuplotting/gnuplot-palettes, such as "viridis", "parula", "jet".
     auto palette(const std::string& name) -> multiplot&;
@@ -70,15 +74,23 @@ class multiplot
     /// Note that if you're changing the plot afterwards, changes will NOT be recorded in the multiplot.
     auto add(const plot& p) -> multiplot&;
 
+    /// Write the current plot data of all plots to the data file(s).
+    auto saveplotdata() const -> void;
+
     /// Show the plot in a pop-up window.
-    auto show() -> void;
+    /// Will remove temporary files after showing if autoclean(true) (default).
+    auto show() const -> void;
 
     /// Save the plot in a file, with its extension defining the figure format.
     /// The extension of the file name determines the format of the figure.
     /// The supported figure formats are: `pdf`, `eps`, `svg`, `png`, and `jpeg`.
     /// Thus, to save a plot in `png` format, choose a file name with a `.png`
     /// file extension as in `fig.png`.
-    auto save(const std::string& filename) -> void;
+    /// Will remove temporary files after saving if autoclean(true) (default).
+    auto save(const std::string& filename) const -> void;
+
+    /// Delete all files used to store plot data or scripts.
+    auto cleanup() const -> void;
 
   private:
     /// Counter of how many plot / singleplot objects have been instanciated in the application
@@ -87,6 +99,9 @@ class multiplot
     /// Plot id derived from m_counter upon construction
     /// Must be the first member due to constructor initialization order!
     std::size_t m_id = 0;
+
+    /// Toggle automatic cleaning of temporary files (enabled by default)
+    bool m_autoclean = true;
 
     /// The name of the gnuplot palette to be used
     std::string m_palette;
@@ -121,6 +136,11 @@ multiplot::multiplot()
 {
 }
 
+auto multiplot::autoclean(bool enable) -> void
+{
+    m_autoclean = enable;
+}
+
 auto multiplot::palette(const std::string& name) -> multiplot&
 {
     m_palette = name;
@@ -153,7 +173,15 @@ auto multiplot::add(const plot& p) -> multiplot&
     return *this;
 }
 
-auto multiplot::show() -> void
+auto multiplot::saveplotdata() const -> void
+{
+    for (const auto& p : m_plots)
+    {
+        p.saveplotdata();
+    }
+}
+
+auto multiplot::show() const -> void
 {
     // Open script file and truncate it
     std::ofstream script(m_scriptfilename);
@@ -177,13 +205,20 @@ auto multiplot::show() -> void
     script << std::endl;
     script.close();
 
+    // save plot data to file(s)
+    saveplotdata();
+
     // Show the plot
     gnuplot::runscript(m_scriptfilename, true);
-    // Remove the no longer needed show{#}.plt file
-    //        std::remove(m_scriptfilename.c_str());
+
+    // remove the temporary files if user wants to
+    if (m_autoclean)
+    {
+        cleanup();
+    }
 }
 
-auto multiplot::save(const std::string& filename) -> void
+auto multiplot::save(const std::string& filename) const -> void
 {
     // Clean the file name to prevent errors
     auto cleanedfilename = gnuplot::cleanpath(filename);
@@ -226,8 +261,26 @@ auto multiplot::save(const std::string& filename) -> void
     script << std::endl;
     script.close();
 
+    // save plot data to file(s)
+    saveplotdata();
+
     // Save the plot as a file
     gnuplot::runscript(m_scriptfilename, false);
+
+    // remove the temporary files if user wants to
+    if (m_autoclean)
+    {
+        cleanup();
+    }
+}
+
+auto multiplot::cleanup() const -> void
+{
+    std::remove(m_scriptfilename.c_str());
+    for (const auto& p : m_plots)
+    {
+        p.cleanup();
+    }
 }
 
 } // namespace sciplot

--- a/sciplot/util.hpp
+++ b/sciplot/util.hpp
@@ -189,9 +189,6 @@ auto writedataset(std::ostream& out, std::size_t index, const Args&... args) -> 
     // Ensure two blank lines are added here so that gnuplot understands a new data set has been added
     out << "\n\n";
 
-    // Flush the file data to ensure its correct state when gnuplot is called
-    out.flush();
-
     return out;
 }
 

--- a/sciplot/util.hpp
+++ b/sciplot/util.hpp
@@ -237,7 +237,7 @@ auto outputcmd(std::ostream& out, const std::string& filename) -> std::ostream&
 }
 
 /// Auxiliary function to write multiplot commands to a script file
-auto multiplotcmd(std::ostream& out, std::size_t rows, std::size_t columns, const std::string& title) -> std::ostream&
+auto multiplotcmd(std::ostream& out, std::size_t rows, std::size_t columns, fillordertype fillorder, growdirectiontype growdir, const std::string& title) -> std::ostream&
 {
     out << "#==============================================================================" << std::endl;
     out << "# MULTIPLOT" << std::endl;
@@ -247,6 +247,8 @@ auto multiplotcmd(std::ostream& out, std::size_t rows, std::size_t columns, cons
     {
         out << " layout " << rows << "," << columns;
     }
+    out << " " << fillordertypestr(fillorder);
+    out << " " << growdirectiontypestr(growdir);
     if (!title.empty())
     {
         out << " title \"" << title << "\"";


### PR DESCRIPTION
Added plot:: / multiplot::clean() to remove files and ::autoclean(bool) to enable auto-removal after show() / save(). Enabled by default. Plot data is saved to file by calling ::saveplotdata().