### PR TITLE
Add missing include for compiling with msvc 2019

### DIFF
--- a/sciplot/specs/plotspecs.hpp
+++ b/sciplot/specs/plotspecs.hpp
@@ -32,6 +32,9 @@
 #include <sciplot/specs/linespecs.hpp>
 #include <sciplot/util.hpp>
 
+// C++ includes
+#include <algorithm>
+
 namespace sciplot
 {
 


### PR DESCRIPTION
<algorithm> include is missing if compiling with msvc 2019