### PR TITLE
Update docs with filled curves example

### DIFF
--- a/docs/website/img/tutorials/example-filled-curves.svg
+++ b/docs/website/img/tutorials/example-filled-curves.svg
@@ -1,0 +1,706 @@
+<?xml version="1.0" encoding="utf-8"  standalone="no"?>
+<svg 
+ width="749" height="749"
+ viewBox="0 0 749 749"
+ xmlns="http://www.w3.org/2000/svg"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+>
+
+<title>Gnuplot</title>
+<desc>Produced by GNUPLOT 5.2 patchlevel 8 </desc>
+
+<g id="gnuplot_canvas">
+
+<rect x="0" y="0" width="749" height="749" fill="none"/>
+<defs>
+
+	<circle id='gpDot' r='0.5' stroke-width='0.5' stroke='currentColor'/>
+	<path id='gpPt0' stroke-width='0.222' stroke='currentColor' d='M-1,0 h2 M0,-1 v2'/>
+	<path id='gpPt1' stroke-width='0.222' stroke='currentColor' d='M-1,-1 L1,1 M1,-1 L-1,1'/>
+	<path id='gpPt2' stroke-width='0.222' stroke='currentColor' d='M-1,0 L1,0 M0,-1 L0,1 M-1,-1 L1,1 M-1,1 L1,-1'/>
+	<rect id='gpPt3' stroke-width='0.222' stroke='currentColor' x='-1' y='-1' width='2' height='2'/>
+	<rect id='gpPt4' stroke-width='0.222' stroke='currentColor' fill='currentColor' x='-1' y='-1' width='2' height='2'/>
+	<circle id='gpPt5' stroke-width='0.222' stroke='currentColor' cx='0' cy='0' r='1'/>
+	<use xlink:href='#gpPt5' id='gpPt6' fill='currentColor' stroke='none'/>
+	<path id='gpPt7' stroke-width='0.222' stroke='currentColor' d='M0,-1.33 L-1.33,0.67 L1.33,0.67 z'/>
+	<use xlink:href='#gpPt7' id='gpPt8' fill='currentColor' stroke='none'/>
+	<use xlink:href='#gpPt7' id='gpPt9' stroke='currentColor' transform='rotate(180)'/>
+	<use xlink:href='#gpPt9' id='gpPt10' fill='currentColor' stroke='none'/>
+	<use xlink:href='#gpPt3' id='gpPt11' stroke='currentColor' transform='rotate(45)'/>
+	<use xlink:href='#gpPt11' id='gpPt12' fill='currentColor' stroke='none'/>
+	<path id='gpPt13' stroke-width='0.222' stroke='currentColor' d='M0,1.330 L1.265,0.411 L0.782,-1.067 L-0.782,-1.076 L-1.265,0.411 z'/>
+	<use xlink:href='#gpPt13' id='gpPt14' fill='currentColor' stroke='none'/>
+	<filter id='textbox' filterUnits='objectBoundingBox' x='0' y='0' height='1' width='1'>
+	  <feFlood flood-color='white' flood-opacity='1' result='bgnd'/>
+	  <feComposite in='SourceGraphic' in2='bgnd' operator='atop'/>
+	</filter>
+	<filter id='greybox' filterUnits='objectBoundingBox' x='0' y='0' height='1' width='1'>
+	  <feFlood flood-color='lightgrey' flood-opacity='1' result='grey'/>
+	  <feComposite in='SourceGraphic' in2='grey' operator='atop'/>
+	</filter>
+</defs>
+<g fill="none" color="white" stroke="currentColor" stroke-width="1.00" stroke-linecap="round" stroke-linejoin="round">
+	<g transform="translate(374.5,21.9)" stroke="none" fill="black" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" >Filled curves &amp; options</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="1.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,343.0 L53.9,343.0  '/>	<g transform="translate(45.6,346.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,327.7 L56.2,327.7 M58.4,312.3 L56.2,312.3 M58.4,297.0 L56.2,297.0 M58.4,281.6 L56.2,281.6
+		M58.4,266.3 L53.9,266.3  '/>	<g transform="translate(45.6,270.2)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,250.9 L56.2,250.9 M58.4,235.6 L56.2,235.6 M58.4,220.2 L56.2,220.2 M58.4,204.9 L56.2,204.9
+		M58.4,189.5 L53.9,189.5  '/>	<g transform="translate(45.6,193.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,174.2 L56.2,174.2 M58.4,158.9 L56.2,158.9 M58.4,143.5 L56.2,143.5 M58.4,128.2 L56.2,128.2
+		M58.4,112.8 L53.9,112.8  '/>	<g transform="translate(45.6,116.7)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,97.5 L56.2,97.5 M58.4,82.1 L56.2,82.1 M58.4,66.8 L56.2,66.8 M58.4,51.4 L56.2,51.4
+		M58.4,36.1 L53.9,36.1  '/>	<g transform="translate(45.6,40.0)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,343.0 L58.4,347.5  '/>	<g transform="translate(58.4,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M66.7,343.0 L66.7,345.2 M75.0,343.0 L75.0,345.2 M83.4,343.0 L83.4,345.2 M91.7,343.0 L91.7,345.2
+		M100.0,343.0 L100.0,347.5  '/>	<g transform="translate(100.0,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M108.3,343.0 L108.3,345.2 M116.6,343.0 L116.6,345.2 M124.9,343.0 L124.9,345.2 M133.3,343.0 L133.3,345.2
+		M141.6,343.0 L141.6,347.5  '/>	<g transform="translate(141.6,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 2</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M149.9,343.0 L149.9,345.2 M158.2,343.0 L158.2,345.2 M166.5,343.0 L166.5,345.2 M174.8,343.0 L174.8,345.2
+		M183.2,343.0 L183.2,347.5  '/>	<g transform="translate(183.2,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 3</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M191.5,343.0 L191.5,345.2 M199.8,343.0 L199.8,345.2 M208.1,343.0 L208.1,345.2 M216.4,343.0 L216.4,345.2
+		M224.7,343.0 L224.7,347.5  '/>	<g transform="translate(224.7,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M233.1,343.0 L233.1,345.2 M241.4,343.0 L241.4,345.2 M249.7,343.0 L249.7,345.2 M258.0,343.0 L258.0,345.2
+		M266.3,343.0 L266.3,347.5  '/>	<g transform="translate(266.3,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M274.6,343.0 L274.6,345.2 M283.0,343.0 L283.0,345.2 M291.3,343.0 L291.3,345.2 M299.6,343.0 L299.6,345.2
+		M307.9,343.0 L307.9,347.5  '/>	<g transform="translate(307.9,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 6</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M316.2,343.0 L316.2,345.2 M324.5,343.0 L324.5,345.2 M332.9,343.0 L332.9,345.2 M341.2,343.0 L341.2,345.2
+		M349.5,343.0 L349.5,347.5  '/>	<g transform="translate(349.5,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 7</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,36.1 L58.4,343.0 L349.5,343.0 M349.5,36.1 M58.4,36.1  '/></g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+	<g id="gnuplot_plot_1a" ><title>sin(x) default</title>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'rgb( 27, 158, 119)' points = '58.4,189.5 59.7,184.7 61.0,179.9 62.3,175.1 63.6,170.3 64.9,165.5 66.2,160.8 67.5,156.1 68.9,151.4 70.2,146.7 71.5,142.1 72.8,137.6 74.1,133.1 75.4,128.6 76.7,124.2 78.0,119.9
+79.3,115.6 80.6,111.4 81.9,107.3 83.2,103.3 84.5,99.4 85.8,95.5 87.1,91.7 88.4,88.1 89.8,84.5 91.1,81.0 92.4,77.7 93.7,74.4 95.0,71.3 96.3,68.3 97.6,65.4 98.9,62.6
+100.2,60.0 101.5,57.5 102.8,55.1 104.1,52.8 105.4,50.7 106.7,48.7 108.0,46.9 109.4,45.2 110.7,43.6 112.0,42.2 113.3,40.9 114.6,39.8 115.9,38.8 117.2,38.0 118.5,37.3 119.8,36.8
+121.1,36.4 122.4,36.2 123.7,36.1 125.0,36.2 126.3,36.4 127.6,36.8 128.9,37.3 130.3,38.0 131.6,38.8 132.9,39.8 134.2,40.9 135.5,42.2 136.8,43.6 138.1,45.2 139.4,46.9 140.7,48.7
+142.0,50.7 143.3,52.8 144.6,55.1 145.9,57.5 147.2,60.0 148.5,62.6 149.9,65.4 151.2,68.3 152.5,71.3 153.8,74.4 155.1,77.7 156.4,81.0 157.7,84.5 159.0,88.1 160.3,91.7 161.6,95.5
+162.9,99.4 164.2,103.3 165.5,107.3 166.8,111.4 168.1,115.6 169.4,119.9 170.8,124.2 172.1,128.6 173.4,133.1 174.7,137.6 176.0,142.1 177.3,146.7 178.6,151.4 179.9,156.1 181.2,160.8 182.5,165.5
+183.8,170.3 185.1,175.1 186.4,179.9 187.7,184.7 189.0,189.6 190.4,194.4 191.7,199.2 193.0,204.0 194.3,208.8 195.6,213.6 196.9,218.3 198.2,223.0 199.5,227.7 200.8,232.4 202.1,237.0 203.4,241.5
+204.7,246.0 206.0,250.5 207.3,254.9 208.6,259.2 209.9,263.5 211.3,267.7 212.6,271.8 213.9,275.8 215.2,279.7 216.5,283.6 217.8,287.4 219.1,291.0 220.4,294.6 221.7,298.1 223.0,301.4 224.3,304.7
+225.6,307.8 226.9,310.8 228.2,313.7 229.5,316.5 230.9,319.1 232.2,321.6 233.5,324.0 234.8,326.3 236.1,328.4 237.4,330.4 238.7,332.2 240.0,333.9 241.3,335.5 242.6,336.9 243.9,338.2 245.2,339.3
+246.5,340.3 247.8,341.1 249.1,341.8 250.4,342.3 251.8,342.7 253.1,342.9 254.4,343.0 255.7,342.9 257.0,342.7 258.3,342.3 259.6,341.8 260.9,341.1 262.2,340.3 263.5,339.3 264.8,338.2 266.1,336.9
+267.4,335.5 268.7,333.9 270.0,332.2 271.4,330.4 272.7,328.4 274.0,326.3 275.3,324.0 276.6,321.6 277.9,319.1 279.2,316.5 280.5,313.7 281.8,310.8 283.1,307.8 284.4,304.7 285.7,301.4 287.0,298.1
+288.3,294.6 289.6,291.0 290.9,287.4 292.3,283.6 293.6,279.7 294.9,275.8 296.2,271.8 297.5,267.7 298.8,263.5 300.1,259.2 301.4,254.9 302.7,250.5 304.0,246.0 305.3,241.5 306.6,237.0 307.9,232.4
+309.2,227.7 310.5,223.0 311.9,218.3 313.2,213.6 314.5,208.8 315.8,204.0 317.1,199.2 318.4,194.4 319.7,189.5 '/>
+		<polygon fill = 'rgb( 27, 158, 119)' points = '58.4,189.5 '/>
+	</g>
+</g>
+	</g>
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'white' points = '166.2,81.1 341.2,81.1 341.2,45.1 166.2,45.1 '/>
+	</g>
+	<g id="gnuplot_plot_1a" ><title>sin(x) default</title>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g transform="translate(225.0,67.0)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="start">
+		<text><tspan font-family="Arial" >sin(x) default</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'rgb( 27, 158, 119)' points = '174.5,67.6 216.7,67.6 216.7,58.6 174.5,58.6 '/>
+	</g>
+</g>
+	</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,343.0 L53.9,343.0  '/>	<g transform="translate(45.6,346.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,327.7 L56.2,327.7 M58.4,312.3 L56.2,312.3 M58.4,297.0 L56.2,297.0 M58.4,281.6 L56.2,281.6
+		M58.4,266.3 L53.9,266.3  '/>	<g transform="translate(45.6,270.2)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,250.9 L56.2,250.9 M58.4,235.6 L56.2,235.6 M58.4,220.2 L56.2,220.2 M58.4,204.9 L56.2,204.9
+		M58.4,189.5 L53.9,189.5  '/>	<g transform="translate(45.6,193.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,174.2 L56.2,174.2 M58.4,158.9 L56.2,158.9 M58.4,143.5 L56.2,143.5 M58.4,128.2 L56.2,128.2
+		M58.4,112.8 L53.9,112.8  '/>	<g transform="translate(45.6,116.7)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,97.5 L56.2,97.5 M58.4,82.1 L56.2,82.1 M58.4,66.8 L56.2,66.8 M58.4,51.4 L56.2,51.4
+		M58.4,36.1 L53.9,36.1  '/>	<g transform="translate(45.6,40.0)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,343.0 L58.4,347.5  '/>	<g transform="translate(58.4,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M66.7,343.0 L66.7,345.2 M75.0,343.0 L75.0,345.2 M83.4,343.0 L83.4,345.2 M91.7,343.0 L91.7,345.2
+		M100.0,343.0 L100.0,347.5  '/>	<g transform="translate(100.0,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M108.3,343.0 L108.3,345.2 M116.6,343.0 L116.6,345.2 M124.9,343.0 L124.9,345.2 M133.3,343.0 L133.3,345.2
+		M141.6,343.0 L141.6,347.5  '/>	<g transform="translate(141.6,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 2</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M149.9,343.0 L149.9,345.2 M158.2,343.0 L158.2,345.2 M166.5,343.0 L166.5,345.2 M174.8,343.0 L174.8,345.2
+		M183.2,343.0 L183.2,347.5  '/>	<g transform="translate(183.2,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 3</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M191.5,343.0 L191.5,345.2 M199.8,343.0 L199.8,345.2 M208.1,343.0 L208.1,345.2 M216.4,343.0 L216.4,345.2
+		M224.7,343.0 L224.7,347.5  '/>	<g transform="translate(224.7,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M233.1,343.0 L233.1,345.2 M241.4,343.0 L241.4,345.2 M249.7,343.0 L249.7,345.2 M258.0,343.0 L258.0,345.2
+		M266.3,343.0 L266.3,347.5  '/>	<g transform="translate(266.3,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M274.6,343.0 L274.6,345.2 M283.0,343.0 L283.0,345.2 M291.3,343.0 L291.3,345.2 M299.6,343.0 L299.6,345.2
+		M307.9,343.0 L307.9,347.5  '/>	<g transform="translate(307.9,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 6</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M316.2,343.0 L316.2,345.2 M324.5,343.0 L324.5,345.2 M332.9,343.0 L332.9,345.2 M341.2,343.0 L341.2,345.2
+		M349.5,343.0 L349.5,347.5  '/>	<g transform="translate(349.5,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 7</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,36.1 L58.4,343.0 L349.5,343.0 M349.5,36.1 M58.4,36.1  '/></g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,343.0 L428.4,343.0  '/>	<g transform="translate(420.1,346.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,327.7 L430.7,327.7 M432.9,312.3 L430.7,312.3 M432.9,297.0 L430.7,297.0 M432.9,281.6 L430.7,281.6
+		M432.9,266.3 L428.4,266.3  '/>	<g transform="translate(420.1,270.2)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,250.9 L430.7,250.9 M432.9,235.6 L430.7,235.6 M432.9,220.2 L430.7,220.2 M432.9,204.9 L430.7,204.9
+		M432.9,189.5 L428.4,189.5  '/>	<g transform="translate(420.1,193.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,174.2 L430.7,174.2 M432.9,158.9 L430.7,158.9 M432.9,143.5 L430.7,143.5 M432.9,128.2 L430.7,128.2
+		M432.9,112.8 L428.4,112.8  '/>	<g transform="translate(420.1,116.7)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,97.5 L430.7,97.5 M432.9,82.1 L430.7,82.1 M432.9,66.8 L430.7,66.8 M432.9,51.4 L430.7,51.4
+		M432.9,36.1 L428.4,36.1  '/>	<g transform="translate(420.1,40.0)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,343.0 L432.9,347.5  '/>	<g transform="translate(432.9,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M441.2,343.0 L441.2,345.2 M449.5,343.0 L449.5,345.2 M457.9,343.0 L457.9,345.2 M466.2,343.0 L466.2,345.2
+		M474.5,343.0 L474.5,347.5  '/>	<g transform="translate(474.5,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M482.8,343.0 L482.8,345.2 M491.1,343.0 L491.1,345.2 M499.4,343.0 L499.4,345.2 M507.8,343.0 L507.8,345.2
+		M516.1,343.0 L516.1,347.5  '/>	<g transform="translate(516.1,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 2</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M524.4,343.0 L524.4,345.2 M532.7,343.0 L532.7,345.2 M541.0,343.0 L541.0,345.2 M549.3,343.0 L549.3,345.2
+		M557.7,343.0 L557.7,347.5  '/>	<g transform="translate(557.7,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 3</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M566.0,343.0 L566.0,345.2 M574.3,343.0 L574.3,345.2 M582.6,343.0 L582.6,345.2 M590.9,343.0 L590.9,345.2
+		M599.2,343.0 L599.2,347.5  '/>	<g transform="translate(599.2,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M607.6,343.0 L607.6,345.2 M615.9,343.0 L615.9,345.2 M624.2,343.0 L624.2,345.2 M632.5,343.0 L632.5,345.2
+		M640.8,343.0 L640.8,347.5  '/>	<g transform="translate(640.8,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M649.1,343.0 L649.1,345.2 M657.5,343.0 L657.5,345.2 M665.8,343.0 L665.8,345.2 M674.1,343.0 L674.1,345.2
+		M682.4,343.0 L682.4,347.5  '/>	<g transform="translate(682.4,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 6</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M690.7,343.0 L690.7,345.2 M699.0,343.0 L699.0,345.2 M707.4,343.0 L707.4,345.2 M715.7,343.0 L715.7,345.2
+		M724.0,343.0 L724.0,347.5  '/>	<g transform="translate(724.0,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 7</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,36.1 L432.9,343.0 L724.0,343.0 M724.0,36.1 M432.9,36.1  '/></g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+	<g id="gnuplot_plot_1b" ><title>sin(x) &amp; sin(2x) default</title>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'rgb(255,   0,   0)' points = '432.9,189.5 432.9,189.5 432.9,189.5 '/>
+		<polygon fill = 'rgb(255,   0,   0)' points = '432.9,189.5 434.2,184.7 435.5,179.9 436.8,175.1 438.1,170.3 439.4,165.5 440.7,160.8 442.0,156.1 443.4,151.4 444.7,146.7 446.0,142.1 447.3,137.6 448.6,133.1 449.9,128.6 451.2,124.2 452.5,119.9
+453.8,115.6 455.1,111.4 456.4,107.3 457.7,103.3 459.0,99.4 460.3,95.5 461.6,91.7 462.9,88.1 464.3,84.5 465.6,81.0 466.9,77.7 468.2,74.4 469.5,71.3 470.8,68.3 472.1,65.4 473.4,62.6
+474.7,60.0 476.0,57.5 476.4,56.7 476.0,55.1 474.7,50.7 473.4,46.9 472.1,43.6 470.8,40.9 469.5,38.8 468.2,37.3 466.9,36.4 465.6,36.1 464.3,36.4 462.9,37.3 461.6,38.8 460.3,40.9
+459.0,43.6 457.7,46.9 456.4,50.7 455.1,55.1 453.8,60.0 452.5,65.4 451.2,71.3 449.9,77.7 448.6,84.5 447.3,91.7 446.0,99.4 444.7,107.3 443.4,115.6 442.0,124.2 440.7,133.1 439.4,142.1
+438.1,151.4 436.8,160.8 435.5,170.3 434.2,179.9 '/>
+		<polygon fill = 'rgb(255,   0,   0)' points = '476.4,56.7 477.3,55.1 478.6,52.8 479.9,50.7 481.2,48.7 482.5,46.9 483.9,45.2 485.2,43.6 486.5,42.2 487.8,40.9 489.1,39.8 490.4,38.8 491.7,38.0 493.0,37.3 494.3,36.8 495.6,36.4
+496.9,36.2 498.2,36.1 499.5,36.2 500.8,36.4 502.1,36.8 503.4,37.3 504.8,38.0 506.1,38.8 507.4,39.8 508.7,40.9 510.0,42.2 511.3,43.6 512.6,45.2 513.9,46.9 515.2,48.7 516.5,50.7
+517.8,52.8 519.1,55.1 520.4,57.5 521.7,60.0 523.0,62.6 524.4,65.4 525.7,68.3 527.0,71.3 528.3,74.4 529.6,77.7 530.9,81.0 532.2,84.5 533.5,88.1 534.8,91.7 536.1,95.5 537.4,99.4
+538.7,103.3 540.0,107.3 541.3,111.4 542.6,115.6 543.9,119.9 545.3,124.2 546.6,128.6 547.9,133.1 549.2,137.6 550.5,142.1 551.8,146.7 553.1,151.4 554.4,156.1 555.7,160.8 557.0,165.5 558.3,170.3
+559.6,175.1 560.9,179.9 562.2,184.7 563.5,189.5 562.2,199.2 560.9,208.8 559.6,218.3 558.3,227.7 557.0,237.0 555.7,246.0 554.4,254.9 553.1,263.5 551.8,271.8 550.5,279.7 549.2,287.4 547.9,294.6
+546.6,301.4 545.3,307.8 543.9,313.7 542.6,319.1 541.3,324.0 540.0,328.4 538.7,332.2 537.4,335.5 536.1,338.2 534.8,340.3 533.5,341.8 532.2,342.7 530.9,343.0 529.6,342.7 528.3,341.8 527.0,340.3
+525.7,338.2 524.4,335.5 523.0,332.2 521.7,328.4 520.4,324.0 519.1,319.1 517.8,313.7 516.5,307.8 515.2,301.4 513.9,294.6 512.6,287.4 511.3,279.7 510.0,271.8 508.7,263.5 507.4,254.9 506.1,246.0
+504.8,237.0 503.4,227.7 502.1,218.3 500.8,208.8 499.5,199.2 498.2,189.6 496.9,179.9 495.6,170.3 494.3,160.8 493.0,151.4 491.7,142.1 490.4,133.1 489.1,124.2 487.8,115.6 486.5,107.3 485.2,99.4
+483.9,91.7 482.5,84.5 481.2,77.7 479.9,71.3 478.6,65.4 477.3,60.0 '/>
+		<polygon fill = 'rgb(255,   0,   0)' points = '563.5,189.5 563.5,189.6 564.9,194.4 566.2,199.2 567.5,204.0 568.8,208.8 570.1,213.6 571.4,218.3 572.7,223.0 574.0,227.7 575.3,232.4 576.6,237.0 577.9,241.5 579.2,246.0 580.5,250.5 581.8,254.9
+583.1,259.2 584.4,263.5 585.8,267.7 587.1,271.8 588.4,275.8 589.7,279.7 591.0,283.6 592.3,287.4 593.6,291.0 594.9,294.6 596.2,298.1 597.5,301.4 598.8,304.7 600.1,307.8 601.4,310.8 602.7,313.7
+604.0,316.5 605.4,319.1 606.7,321.6 608.0,324.0 609.3,326.3 610.6,328.4 611.9,330.4 613.2,332.2 614.5,333.9 615.8,335.5 617.1,336.9 618.4,338.2 619.7,339.3 621.0,340.3 622.3,341.1 623.6,341.8
+624.9,342.3 626.3,342.7 627.6,342.9 628.9,343.0 630.2,342.9 631.5,342.7 632.8,342.3 634.1,341.8 635.4,341.1 636.7,340.3 638.0,339.3 639.3,338.2 640.6,336.9 641.9,335.5 643.2,333.9 644.5,332.2
+645.9,330.4 647.2,328.4 648.5,326.3 649.8,324.0 650.7,322.4 649.8,319.1 648.5,313.7 647.2,307.8 645.9,301.4 644.5,294.6 643.2,287.4 641.9,279.7 640.6,271.8 639.3,263.5 638.0,254.9 636.7,246.0
+635.4,237.0 634.1,227.7 632.8,218.3 631.5,208.8 630.2,199.2 628.9,189.6 627.6,179.9 626.3,170.3 624.9,160.8 623.6,151.4 622.3,142.1 621.0,133.1 619.7,124.2 618.4,115.6 617.1,107.3 615.8,99.4
+614.5,91.7 613.2,84.5 611.9,77.7 610.6,71.3 609.3,65.4 608.0,60.0 606.7,55.1 605.4,50.7 604.0,46.9 602.7,43.6 601.4,40.9 600.1,38.8 598.8,37.3 597.5,36.4 596.2,36.1 594.9,36.4
+593.6,37.3 592.3,38.8 591.0,40.9 589.7,43.6 588.4,46.9 587.1,50.7 585.8,55.1 584.4,60.0 583.1,65.4 581.8,71.3 580.5,77.7 579.2,84.5 577.9,91.7 576.6,99.4 575.3,107.3 574.0,115.6
+572.7,124.2 571.4,133.1 570.1,142.1 568.8,151.4 567.5,160.8 566.2,170.3 564.9,179.9 563.5,189.5 '/>
+		<polygon fill = 'rgb(255,   0,   0)' points = '650.7,322.4 651.1,321.6 652.4,319.1 653.7,316.5 655.0,313.7 656.3,310.8 657.6,307.8 658.9,304.7 660.2,301.4 661.5,298.1 662.8,294.6 664.1,291.0 665.4,287.4 666.8,283.6 668.1,279.7 669.4,275.8
+670.7,271.8 672.0,267.7 673.3,263.5 674.6,259.2 675.9,254.9 677.2,250.5 678.5,246.0 679.8,241.5 681.1,237.0 682.4,232.4 683.7,227.7 685.0,223.0 686.4,218.3 687.7,213.6 689.0,208.8 690.3,204.0
+691.6,199.2 692.9,194.4 694.2,189.6 692.9,199.2 691.6,208.8 690.3,218.3 689.0,227.7 687.7,237.0 686.4,246.0 685.0,254.9 683.7,263.5 682.4,271.8 681.1,279.7 679.8,287.4 678.5,294.6 677.2,301.4
+675.9,307.8 674.6,313.7 673.3,319.1 672.0,324.0 670.7,328.4 669.4,332.2 668.1,335.5 666.8,338.2 665.4,340.3 664.1,341.8 662.8,342.7 661.5,343.0 660.2,342.7 658.9,341.8 657.6,340.3 656.3,338.2
+655.0,335.5 653.7,332.2 652.4,328.4 651.1,324.0 '/>
+		<polygon fill = 'rgb(255,   0,   0)' points = '694.2,189.6 694.2,189.5 694.2,189.5 '/>
+	</g>
+</g>
+	</g>
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'white' points = '457.7,81.1 715.7,81.1 715.7,45.1 457.7,45.1 '/>
+	</g>
+	<g id="gnuplot_plot_1b" ><title>sin(x) &amp; sin(2x) default</title>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g transform="translate(516.5,67.0)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="start">
+		<text><tspan font-family="Arial" >sin(x) &amp; sin(2x) default</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'rgb(255,   0,   0)' points = '466.0,67.6 508.2,67.6 508.2,58.6 466.0,58.6 '/>
+	</g>
+</g>
+	</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,343.0 L428.4,343.0  '/>	<g transform="translate(420.1,346.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,327.7 L430.7,327.7 M432.9,312.3 L430.7,312.3 M432.9,297.0 L430.7,297.0 M432.9,281.6 L430.7,281.6
+		M432.9,266.3 L428.4,266.3  '/>	<g transform="translate(420.1,270.2)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,250.9 L430.7,250.9 M432.9,235.6 L430.7,235.6 M432.9,220.2 L430.7,220.2 M432.9,204.9 L430.7,204.9
+		M432.9,189.5 L428.4,189.5  '/>	<g transform="translate(420.1,193.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,174.2 L430.7,174.2 M432.9,158.9 L430.7,158.9 M432.9,143.5 L430.7,143.5 M432.9,128.2 L430.7,128.2
+		M432.9,112.8 L428.4,112.8  '/>	<g transform="translate(420.1,116.7)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,97.5 L430.7,97.5 M432.9,82.1 L430.7,82.1 M432.9,66.8 L430.7,66.8 M432.9,51.4 L430.7,51.4
+		M432.9,36.1 L428.4,36.1  '/>	<g transform="translate(420.1,40.0)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,343.0 L432.9,347.5  '/>	<g transform="translate(432.9,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M441.2,343.0 L441.2,345.2 M449.5,343.0 L449.5,345.2 M457.9,343.0 L457.9,345.2 M466.2,343.0 L466.2,345.2
+		M474.5,343.0 L474.5,347.5  '/>	<g transform="translate(474.5,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M482.8,343.0 L482.8,345.2 M491.1,343.0 L491.1,345.2 M499.4,343.0 L499.4,345.2 M507.8,343.0 L507.8,345.2
+		M516.1,343.0 L516.1,347.5  '/>	<g transform="translate(516.1,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 2</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M524.4,343.0 L524.4,345.2 M532.7,343.0 L532.7,345.2 M541.0,343.0 L541.0,345.2 M549.3,343.0 L549.3,345.2
+		M557.7,343.0 L557.7,347.5  '/>	<g transform="translate(557.7,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 3</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M566.0,343.0 L566.0,345.2 M574.3,343.0 L574.3,345.2 M582.6,343.0 L582.6,345.2 M590.9,343.0 L590.9,345.2
+		M599.2,343.0 L599.2,347.5  '/>	<g transform="translate(599.2,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M607.6,343.0 L607.6,345.2 M615.9,343.0 L615.9,345.2 M624.2,343.0 L624.2,345.2 M632.5,343.0 L632.5,345.2
+		M640.8,343.0 L640.8,347.5  '/>	<g transform="translate(640.8,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M649.1,343.0 L649.1,345.2 M657.5,343.0 L657.5,345.2 M665.8,343.0 L665.8,345.2 M674.1,343.0 L674.1,345.2
+		M682.4,343.0 L682.4,347.5  '/>	<g transform="translate(682.4,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 6</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M690.7,343.0 L690.7,345.2 M699.0,343.0 L699.0,345.2 M707.4,343.0 L707.4,345.2 M715.7,343.0 L715.7,345.2
+		M724.0,343.0 L724.0,347.5  '/>	<g transform="translate(724.0,369.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 7</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M432.9,36.1 L432.9,343.0 L724.0,343.0 M724.0,36.1 M432.9,36.1  '/></g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,708.5 L53.9,708.5  '/>	<g transform="translate(45.6,712.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,693.1 L56.2,693.1 M58.4,677.8 L56.2,677.8 M58.4,662.4 L56.2,662.4 M58.4,647.1 L56.2,647.1
+		M58.4,631.7 L53.9,631.7  '/>	<g transform="translate(45.6,635.6)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,616.4 L56.2,616.4 M58.4,601.0 L56.2,601.0 M58.4,585.7 L56.2,585.7 M58.4,570.3 L56.2,570.3
+		M58.4,555.0 L53.9,555.0  '/>	<g transform="translate(45.6,558.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,539.6 L56.2,539.6 M58.4,524.3 L56.2,524.3 M58.4,508.9 L56.2,508.9 M58.4,493.6 L56.2,493.6
+		M58.4,478.2 L53.9,478.2  '/>	<g transform="translate(45.6,482.1)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,462.9 L56.2,462.9 M58.4,447.5 L56.2,447.5 M58.4,432.2 L56.2,432.2 M58.4,416.8 L56.2,416.8
+		M58.4,401.5 L53.9,401.5  '/>	<g transform="translate(45.6,405.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,708.5 L58.4,713.0  '/>	<g transform="translate(58.4,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M66.7,708.5 L66.7,710.7 M75.0,708.5 L75.0,710.7 M83.4,708.5 L83.4,710.7 M91.7,708.5 L91.7,710.7
+		M100.0,708.5 L100.0,713.0  '/>	<g transform="translate(100.0,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M108.3,708.5 L108.3,710.7 M116.6,708.5 L116.6,710.7 M124.9,708.5 L124.9,710.7 M133.3,708.5 L133.3,710.7
+		M141.6,708.5 L141.6,713.0  '/>	<g transform="translate(141.6,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 2</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M149.9,708.5 L149.9,710.7 M158.2,708.5 L158.2,710.7 M166.5,708.5 L166.5,710.7 M174.8,708.5 L174.8,710.7
+		M183.2,708.5 L183.2,713.0  '/>	<g transform="translate(183.2,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 3</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M191.5,708.5 L191.5,710.7 M199.8,708.5 L199.8,710.7 M208.1,708.5 L208.1,710.7 M216.4,708.5 L216.4,710.7
+		M224.7,708.5 L224.7,713.0  '/>	<g transform="translate(224.7,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M233.1,708.5 L233.1,710.7 M241.4,708.5 L241.4,710.7 M249.7,708.5 L249.7,710.7 M258.0,708.5 L258.0,710.7
+		M266.3,708.5 L266.3,713.0  '/>	<g transform="translate(266.3,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M274.6,708.5 L274.6,710.7 M283.0,708.5 L283.0,710.7 M291.3,708.5 L291.3,710.7 M299.6,708.5 L299.6,710.7
+		M307.9,708.5 L307.9,713.0  '/>	<g transform="translate(307.9,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 6</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M316.2,708.5 L316.2,710.7 M324.5,708.5 L324.5,710.7 M332.9,708.5 L332.9,710.7 M341.2,708.5 L341.2,710.7
+		M349.5,708.5 L349.5,713.0  '/>	<g transform="translate(349.5,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 7</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,401.5 L58.4,708.5 L349.5,708.5 M349.5,401.5 M58.4,401.5  '/></g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+	<g id="gnuplot_plot_1c" ><title>sin(x) &amp; sin(2x) above</title>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'rgb(  0,   0, 255)' points = '101.9,422.1 102.8,420.5 104.1,418.2 105.4,416.1 106.7,414.1 108.0,412.3 109.4,410.6 110.7,409.0 112.0,407.6 113.3,406.3 114.6,405.2 115.9,404.2 117.2,403.4 118.5,402.7 119.8,402.2 121.1,401.8
+122.4,401.6 123.7,401.5 125.0,401.6 126.3,401.8 127.6,402.2 128.9,402.7 130.3,403.4 131.6,404.2 132.9,405.2 134.2,406.3 135.5,407.6 136.8,409.0 138.1,410.6 139.4,412.3 140.7,414.1 142.0,416.1
+143.3,418.2 144.6,420.5 145.9,422.9 147.2,425.4 148.5,428.0 149.9,430.8 151.2,433.7 152.5,436.7 153.8,439.9 155.1,443.1 156.4,446.5 157.7,449.9 159.0,453.5 160.3,457.2 161.6,460.9 162.9,464.8
+164.2,468.7 165.5,472.8 166.8,476.9 168.1,481.1 169.4,485.3 170.8,489.6 172.1,494.0 173.4,498.5 174.7,503.0 176.0,507.6 177.3,512.2 178.6,516.8 179.9,521.5 181.2,526.2 182.5,531.0 183.8,535.8
+185.1,540.6 186.4,545.4 187.7,550.2 189.0,555.0 187.7,564.6 186.4,574.2 185.1,583.8 183.8,593.2 182.5,602.4 181.2,611.5 179.9,620.4 178.6,628.9 177.3,637.2 176.0,645.2 174.7,652.8 173.4,660.1
+172.1,666.9 170.8,673.3 169.4,679.2 168.1,684.6 166.8,689.5 165.5,693.9 164.2,697.7 162.9,701.0 161.6,703.7 160.3,705.8 159.0,707.3 157.7,708.2 156.4,708.5 155.1,708.2 153.8,707.3 152.5,705.8
+151.2,703.7 149.9,701.0 148.5,697.7 147.2,693.9 145.9,689.5 144.6,684.6 143.3,679.2 142.0,673.3 140.7,666.9 139.4,660.1 138.1,652.8 136.8,645.2 135.5,637.2 134.2,628.9 132.9,620.4 131.6,611.5
+130.3,602.4 128.9,593.2 127.6,583.8 126.3,574.2 125.0,564.6 123.7,555.0 122.4,545.4 121.1,535.8 119.8,526.2 118.5,516.8 117.2,507.6 115.9,498.5 114.6,489.6 113.3,481.1 112.0,472.8 110.7,464.8
+109.4,457.2 108.0,449.9 106.7,443.1 105.4,436.7 104.1,430.8 102.8,425.4 '/>
+		<polygon fill = 'rgb(  0,   0, 255)' points = '276.2,687.9 276.6,687.1 277.9,684.6 279.2,682.0 280.5,679.2 281.8,676.3 283.1,673.3 284.4,670.1 285.7,666.9 287.0,663.5 288.3,660.1 289.6,656.5 290.9,652.8 292.3,649.1 293.6,645.2 294.9,641.3
+296.2,637.2 297.5,633.1 298.8,628.9 300.1,624.7 301.4,620.4 302.7,616.0 304.0,611.5 305.3,607.0 306.6,602.4 307.9,597.8 309.2,593.2 310.5,588.5 311.9,583.8 313.2,579.0 314.5,574.2 315.8,569.4
+317.1,564.6 318.4,559.8 319.7,555.0 318.4,564.6 317.1,574.2 315.8,583.8 314.5,593.2 313.2,602.4 311.9,611.5 310.5,620.4 309.2,628.9 307.9,637.2 306.6,645.2 305.3,652.8 304.0,660.1 302.7,666.9
+301.4,673.3 300.1,679.2 298.8,684.6 297.5,689.5 296.2,693.9 294.9,697.7 293.6,701.0 292.3,703.7 290.9,705.8 289.6,707.3 288.3,708.2 287.0,708.5 285.7,708.2 284.4,707.3 283.1,705.8 281.8,703.7
+280.5,701.0 279.2,697.7 277.9,693.9 276.6,689.5 '/>
+	</g>
+</g>
+	</g>
+	<g id="gnuplot_plot_2c" ><title>sin(x) &amp; sin(2x) below</title>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'rgb(255, 165,   0)' points = '58.4,555.0 58.4,555.0 58.4,555.0 '/>
+		<polygon fill = 'rgb(255, 165,   0)' points = '58.4,555.0 59.7,550.2 61.0,545.4 62.3,540.6 63.6,535.8 64.9,531.0 66.2,526.2 67.5,521.5 68.9,516.8 70.2,512.2 71.5,507.6 72.8,503.0 74.1,498.5 75.4,494.0 76.7,489.6 78.0,485.3
+79.3,481.1 80.6,476.9 81.9,472.8 83.2,468.7 84.5,464.8 85.8,460.9 87.1,457.2 88.4,453.5 89.8,449.9 91.1,446.5 92.4,443.1 93.7,439.9 95.0,436.7 96.3,433.7 97.6,430.8 98.9,428.0
+100.2,425.4 101.5,422.9 101.9,422.1 101.5,420.5 100.2,416.1 98.9,412.3 97.6,409.0 96.3,406.3 95.0,404.2 93.7,402.7 92.4,401.8 91.1,401.5 89.8,401.8 88.4,402.7 87.1,404.2 85.8,406.3
+84.5,409.0 83.2,412.3 81.9,416.1 80.6,420.5 79.3,425.4 78.0,430.8 76.7,436.7 75.4,443.1 74.1,449.9 72.8,457.2 71.5,464.8 70.2,472.8 68.9,481.1 67.5,489.6 66.2,498.5 64.9,507.6
+63.6,516.8 62.3,526.2 61.0,535.8 59.7,545.4 '/>
+		<polygon fill = 'rgb(255, 165,   0)' points = '189.0,555.0 189.0,555.0 190.4,559.8 191.7,564.6 193.0,569.4 194.3,574.2 195.6,579.0 196.9,583.8 198.2,588.5 199.5,593.2 200.8,597.8 202.1,602.4 203.4,607.0 204.7,611.5 206.0,616.0 207.3,620.4
+208.6,624.7 209.9,628.9 211.3,633.1 212.6,637.2 213.9,641.3 215.2,645.2 216.5,649.1 217.8,652.8 219.1,656.5 220.4,660.1 221.7,663.5 223.0,666.9 224.3,670.1 225.6,673.3 226.9,676.3 228.2,679.2
+229.5,682.0 230.9,684.6 232.2,687.1 233.5,689.5 234.8,691.8 236.1,693.9 237.4,695.9 238.7,697.7 240.0,699.4 241.3,701.0 242.6,702.4 243.9,703.7 245.2,704.8 246.5,705.8 247.8,706.6 249.1,707.3
+250.4,707.8 251.8,708.2 253.1,708.4 254.4,708.5 255.7,708.4 257.0,708.2 258.3,707.8 259.6,707.3 260.9,706.6 262.2,705.8 263.5,704.8 264.8,703.7 266.1,702.4 267.4,701.0 268.7,699.4 270.0,697.7
+271.4,695.9 272.7,693.9 274.0,691.8 275.3,689.5 276.2,687.9 275.3,684.6 274.0,679.2 272.7,673.3 271.4,666.9 270.0,660.1 268.7,652.8 267.4,645.2 266.1,637.2 264.8,628.9 263.5,620.4 262.2,611.5
+260.9,602.4 259.6,593.2 258.3,583.8 257.0,574.2 255.7,564.6 254.4,555.0 253.1,545.4 251.8,535.8 250.4,526.2 249.1,516.8 247.8,507.6 246.5,498.5 245.2,489.6 243.9,481.1 242.6,472.8 241.3,464.8
+240.0,457.2 238.7,449.9 237.4,443.1 236.1,436.7 234.8,430.8 233.5,425.4 232.2,420.5 230.9,416.1 229.5,412.3 228.2,409.0 226.9,406.3 225.6,404.2 224.3,402.7 223.0,401.8 221.7,401.5 220.4,401.8
+219.1,402.7 217.8,404.2 216.5,406.3 215.2,409.0 213.9,412.3 212.6,416.1 211.3,420.5 209.9,425.4 208.6,430.8 207.3,436.7 206.0,443.1 204.7,449.9 203.4,457.2 202.1,464.8 200.8,472.8 199.5,481.1
+198.2,489.6 196.9,498.5 195.6,507.6 194.3,516.8 193.0,526.2 191.7,535.8 190.4,545.4 189.0,555.0 '/>
+		<polygon fill = 'rgb(255, 165,   0)' points = '319.7,555.0 319.7,555.0 319.7,555.0 '/>
+	</g>
+</g>
+	</g>
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'white' points = '99.8,464.5 341.2,464.5 341.2,410.5 99.8,410.5 '/>
+	</g>
+	<g id="gnuplot_plot_1c" ><title>sin(x) &amp; sin(2x) above</title>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g transform="translate(158.6,432.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="start">
+		<text><tspan font-family="Arial" >sin(x) &amp; sin(2x) above</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'rgb(  0,   0, 255)' points = '108.1,433.0 150.3,433.0 150.3,424.0 108.1,424.0 '/>
+	</g>
+</g>
+	</g>
+	<g id="gnuplot_plot_2c" ><title>sin(x) &amp; sin(2x) below</title>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g transform="translate(158.6,450.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="start">
+		<text><tspan font-family="Arial" >sin(x) &amp; sin(2x) below</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'rgb(255, 165,   0)' points = '108.1,451.0 150.3,451.0 150.3,442.0 108.1,442.0 '/>
+	</g>
+</g>
+	</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,708.5 L53.9,708.5  '/>	<g transform="translate(45.6,712.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,693.1 L56.2,693.1 M58.4,677.8 L56.2,677.8 M58.4,662.4 L56.2,662.4 M58.4,647.1 L56.2,647.1
+		M58.4,631.7 L53.9,631.7  '/>	<g transform="translate(45.6,635.6)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" >-0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,616.4 L56.2,616.4 M58.4,601.0 L56.2,601.0 M58.4,585.7 L56.2,585.7 M58.4,570.3 L56.2,570.3
+		M58.4,555.0 L53.9,555.0  '/>	<g transform="translate(45.6,558.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,539.6 L56.2,539.6 M58.4,524.3 L56.2,524.3 M58.4,508.9 L56.2,508.9 M58.4,493.6 L56.2,493.6
+		M58.4,478.2 L53.9,478.2  '/>	<g transform="translate(45.6,482.1)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 0.5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,462.9 L56.2,462.9 M58.4,447.5 L56.2,447.5 M58.4,432.2 L56.2,432.2 M58.4,416.8 L56.2,416.8
+		M58.4,401.5 L53.9,401.5  '/>	<g transform="translate(45.6,405.4)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,708.5 L58.4,713.0  '/>	<g transform="translate(58.4,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 0</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M66.7,708.5 L66.7,710.7 M75.0,708.5 L75.0,710.7 M83.4,708.5 L83.4,710.7 M91.7,708.5 L91.7,710.7
+		M100.0,708.5 L100.0,713.0  '/>	<g transform="translate(100.0,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 1</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M108.3,708.5 L108.3,710.7 M116.6,708.5 L116.6,710.7 M124.9,708.5 L124.9,710.7 M133.3,708.5 L133.3,710.7
+		M141.6,708.5 L141.6,713.0  '/>	<g transform="translate(141.6,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 2</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M149.9,708.5 L149.9,710.7 M158.2,708.5 L158.2,710.7 M166.5,708.5 L166.5,710.7 M174.8,708.5 L174.8,710.7
+		M183.2,708.5 L183.2,713.0  '/>	<g transform="translate(183.2,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 3</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M191.5,708.5 L191.5,710.7 M199.8,708.5 L199.8,710.7 M208.1,708.5 L208.1,710.7 M216.4,708.5 L216.4,710.7
+		M224.7,708.5 L224.7,713.0  '/>	<g transform="translate(224.7,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M233.1,708.5 L233.1,710.7 M241.4,708.5 L241.4,710.7 M249.7,708.5 L249.7,710.7 M258.0,708.5 L258.0,710.7
+		M266.3,708.5 L266.3,713.0  '/>	<g transform="translate(266.3,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 5</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M274.6,708.5 L274.6,710.7 M283.0,708.5 L283.0,710.7 M291.3,708.5 L291.3,710.7 M299.6,708.5 L299.6,710.7
+		M307.9,708.5 L307.9,713.0  '/>	<g transform="translate(307.9,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 6</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M316.2,708.5 L316.2,710.7 M324.5,708.5 L324.5,710.7 M332.9,708.5 L332.9,710.7 M341.2,708.5 L341.2,710.7
+		M349.5,708.5 L349.5,713.0  '/>	<g transform="translate(349.5,734.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 7</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M58.4,401.5 L58.4,708.5 L349.5,708.5 M349.5,401.5 M58.4,401.5  '/></g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+</g>
+</svg>
+

--- a/docs/website/tutorials.md
+++ b/docs/website/tutorials.md
@@ -20,6 +20,12 @@ pre-computed and stored in `std::vector` objects (see below).
 
 ![](img/tutorials/example-bessel-functions.svg){: loading=lazy }
 
+## Plotting filled curves
+
+{{ inputcpp('examples/example-filled-curves.cpp', startline=26) }}
+
+![](img/tutorials/example-filled-curves.svg){: loading=lazy }
+
 ## Plotting multiple plots
 
 {{ inputcpp('examples/example-multiplot.cpp', startline=26) }}


### PR DESCRIPTION
Update the docs to link to the filled curves example.
In the future we should agree for a common width for the example plots / svgs in docs. For multiplots and wider plots 749 seems to be a good choice.