### PR TITLE
Logarithmic scales for axes (adresses #62)

### DIFF
--- a/docs/website/img/tutorials/example-logarithmic-axes.svg
+++ b/docs/website/img/tutorials/example-logarithmic-axes.svg
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="utf-8"  standalone="no"?>
+<svg 
+ width="749" height="749"
+ viewBox="0 0 749 749"
+ xmlns="http://www.w3.org/2000/svg"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+>
+
+<title>Gnuplot</title>
+<desc>Produced by GNUPLOT 5.2 patchlevel 8 </desc>
+
+<g id="gnuplot_canvas">
+
+<rect x="0" y="0" width="749" height="749" fill="none"/>
+<defs>
+
+	<circle id='gpDot' r='0.5' stroke-width='0.5' stroke='currentColor'/>
+	<path id='gpPt0' stroke-width='0.222' stroke='currentColor' d='M-1,0 h2 M0,-1 v2'/>
+	<path id='gpPt1' stroke-width='0.222' stroke='currentColor' d='M-1,-1 L1,1 M1,-1 L-1,1'/>
+	<path id='gpPt2' stroke-width='0.222' stroke='currentColor' d='M-1,0 L1,0 M0,-1 L0,1 M-1,-1 L1,1 M-1,1 L1,-1'/>
+	<rect id='gpPt3' stroke-width='0.222' stroke='currentColor' x='-1' y='-1' width='2' height='2'/>
+	<rect id='gpPt4' stroke-width='0.222' stroke='currentColor' fill='currentColor' x='-1' y='-1' width='2' height='2'/>
+	<circle id='gpPt5' stroke-width='0.222' stroke='currentColor' cx='0' cy='0' r='1'/>
+	<use xlink:href='#gpPt5' id='gpPt6' fill='currentColor' stroke='none'/>
+	<path id='gpPt7' stroke-width='0.222' stroke='currentColor' d='M0,-1.33 L-1.33,0.67 L1.33,0.67 z'/>
+	<use xlink:href='#gpPt7' id='gpPt8' fill='currentColor' stroke='none'/>
+	<use xlink:href='#gpPt7' id='gpPt9' stroke='currentColor' transform='rotate(180)'/>
+	<use xlink:href='#gpPt9' id='gpPt10' fill='currentColor' stroke='none'/>
+	<use xlink:href='#gpPt3' id='gpPt11' stroke='currentColor' transform='rotate(45)'/>
+	<use xlink:href='#gpPt11' id='gpPt12' fill='currentColor' stroke='none'/>
+	<path id='gpPt13' stroke-width='0.222' stroke='currentColor' d='M0,1.330 L1.265,0.411 L0.782,-1.067 L-0.782,-1.076 L-1.265,0.411 z'/>
+	<use xlink:href='#gpPt13' id='gpPt14' fill='currentColor' stroke='none'/>
+	<filter id='textbox' filterUnits='objectBoundingBox' x='0' y='0' height='1' width='1'>
+	  <feFlood flood-color='white' flood-opacity='1' result='bgnd'/>
+	  <feComposite in='SourceGraphic' in2='bgnd' operator='atop'/>
+	</filter>
+	<filter id='greybox' filterUnits='objectBoundingBox' x='0' y='0' height='1' width='1'>
+	  <feFlood flood-color='lightgrey' flood-opacity='1' result='grey'/>
+	  <feComposite in='SourceGraphic' in2='grey' operator='atop'/>
+	</filter>
+</defs>
+<g fill="none" color="white" stroke="currentColor" stroke-width="1.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="white" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,593.4 L80.2,593.4  '/>	<g transform="translate(71.9,597.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,478.3 L80.2,478.3  '/>	<g transform="translate(71.9,482.2)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 16</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,363.3 L80.2,363.3  '/>	<g transform="translate(71.9,367.2)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 64</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,248.2 L80.2,248.2  '/>	<g transform="translate(71.9,252.1)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 256</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,133.2 L80.2,133.2  '/>	<g transform="translate(71.9,137.1)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 1024</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,18.1 L80.2,18.1  '/>	<g transform="translate(71.9,22.0)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 4096</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,650.9 L84.7,653.1 M142.8,650.9 L142.8,655.4  '/>	<g transform="translate(142.8,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 2</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M200.9,650.9 L200.9,653.1 M259.1,650.9 L259.1,655.4  '/>	<g transform="translate(259.1,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M317.2,650.9 L317.2,653.1 M375.3,650.9 L375.3,655.4  '/>	<g transform="translate(375.3,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 6</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M433.4,650.9 L433.4,653.1 M491.5,650.9 L491.5,655.4  '/>	<g transform="translate(491.5,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 8</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M549.6,650.9 L549.6,653.1 M607.8,650.9 L607.8,655.4  '/>	<g transform="translate(607.8,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 10</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M665.9,650.9 L665.9,653.1 M724.0,650.9 L724.0,655.4  '/>	<g transform="translate(724.0,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 12</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,18.1 L84.7,650.9 L724.0,650.9 M724.0,18.1 M84.7,18.1  '/></g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g transform="translate(19.0,334.5) rotate(270)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" >y</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g transform="translate(404.3,704.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" >x</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+	<g id="gnuplot_plot_1" ><title>2x</title>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 27, 158, 119)'  d='M84.7,650.9 L91.1,644.6 L97.5,638.2 L103.9,631.9 L110.3,625.6 L116.7,619.3 L123.1,612.9 L129.5,606.6
+		L135.8,600.3 L142.2,593.9 L148.6,587.6 L155.0,581.3 L161.4,575.0 L167.8,568.6 L174.2,562.3 L180.6,556.0
+		L187.0,549.7 L193.4,543.3 L199.8,537.0 L206.2,530.7 L212.6,524.3 L219.0,518.0 L225.3,511.7 L231.7,505.4
+		L238.1,499.0 L244.5,492.7 L250.9,486.4 L257.3,480.0 L263.7,473.7 L270.1,467.4 L276.5,461.1 L282.9,454.7
+		L289.3,448.4 L295.7,442.1 L302.1,435.7 L308.5,429.4 L314.8,423.1 L321.2,416.8 L327.6,410.4 L334.0,404.1
+		L340.4,397.8 L346.8,391.5 L353.2,385.1 L359.6,378.8 L366.0,372.5 L372.4,366.1 L378.8,359.8 L385.2,353.5
+		L391.6,347.2 L398.0,340.8 L404.3,334.5 L410.7,328.2 L417.1,321.8 L423.5,315.5 L429.9,309.2 L436.3,302.9
+		L442.7,296.5 L449.1,290.2 L455.5,283.9 L461.9,277.5 L468.3,271.2 L474.7,264.9 L481.1,258.6 L487.5,252.2
+		L493.9,245.9 L500.2,239.6 L506.6,233.3 L513.0,226.9 L519.4,220.6 L525.8,214.3 L532.2,207.9 L538.6,201.6
+		L545.0,195.3 L551.4,189.0 L557.8,182.6 L564.2,176.3 L570.6,170.0 L577.0,163.6 L583.4,157.3 L589.7,151.0
+		L596.1,144.7 L602.5,138.3 L608.9,132.0 L615.3,125.7 L621.7,119.3 L628.1,113.0 L634.5,106.7 L640.9,100.4
+		L647.3,94.0 L653.7,87.7 L660.1,81.4 L666.5,75.1 L672.9,68.7 L679.2,62.4 L685.6,56.1 L692.0,49.7
+		L698.4,43.4 L704.8,37.1 L711.2,30.8 L717.6,24.4 L724.0,18.1  '/></g>
+	</g>
+	<g stroke='none' shape-rendering='crispEdges'>
+		<polygon fill = 'white' points = '362.5,740.0 446.2,740.0 446.2,704.0 362.5,704.0 '/>
+	</g>
+	<g id="gnuplot_plot_1" ><title>2x</title>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<g transform="translate(421.3,725.9)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="start">
+		<text><tspan font-family="Arial" >2</tspan><tspan font-family="Arial"  font-size="9.6" dy="-6.00px">x</tspan><tspan font-size="12.0" dy="6.00"></tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 27, 158, 119)'  d='M370.8,722.0 L413.0,722.0  '/></g>
+	</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,593.4 L80.2,593.4  '/>	<g transform="translate(71.9,597.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,478.3 L80.2,478.3  '/>	<g transform="translate(71.9,482.2)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 16</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,363.3 L80.2,363.3  '/>	<g transform="translate(71.9,367.2)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 64</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,248.2 L80.2,248.2  '/>	<g transform="translate(71.9,252.1)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 256</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,133.2 L80.2,133.2  '/>	<g transform="translate(71.9,137.1)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 1024</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,18.1 L80.2,18.1  '/>	<g transform="translate(71.9,22.0)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="end">
+		<text><tspan font-family="Arial" > 4096</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,650.9 L84.7,653.1 M142.8,650.9 L142.8,655.4  '/>	<g transform="translate(142.8,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 2</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M200.9,650.9 L200.9,653.1 M259.1,650.9 L259.1,655.4  '/>	<g transform="translate(259.1,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 4</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M317.2,650.9 L317.2,653.1 M375.3,650.9 L375.3,655.4  '/>	<g transform="translate(375.3,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 6</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M433.4,650.9 L433.4,653.1 M491.5,650.9 L491.5,655.4  '/>	<g transform="translate(491.5,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 8</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M549.6,650.9 L549.6,653.1 M607.8,650.9 L607.8,655.4  '/>	<g transform="translate(607.8,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 10</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M665.9,650.9 L665.9,653.1 M724.0,650.9 L724.0,655.4  '/>	<g transform="translate(724.0,677.3)" stroke="none" fill="rgb(64,64,64)" font-family="Arial" font-size="12.00"  text-anchor="middle">
+		<text><tspan font-family="Arial" > 12</tspan></text>
+	</g>
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+	<path stroke='rgb( 64,  64,  64)'  d='M84.7,18.1 L84.7,650.9 L724.0,650.9 M724.0,18.1 M84.7,18.1  '/></g>
+<g fill="none" color="black" stroke="currentColor" stroke-width="2.00" stroke-linecap="round" stroke-linejoin="round">
+</g>
+</g>
+</svg>
+

--- a/docs/website/tutorials.md
+++ b/docs/website/tutorials.md
@@ -26,6 +26,12 @@ pre-computed and stored in `std::vector` objects (see below).
 
 ![](img/tutorials/example-filled-curves.svg){: loading=lazy }
 
+## Using logarithmic axes
+
+{{ inputcpp('examples/example-logarithmic-axes.cpp', startline=26) }}
+
+![](img/tutorials/example-logarithmic-axes.svg){: loading=lazy }
+
 ## Plotting multiple plots
 
 {{ inputcpp('examples/example-multiplot.cpp', startline=26) }}

--- a/examples/example-logarithmic-axes.cpp
+++ b/examples/example-logarithmic-axes.cpp
@@ -1,0 +1,64 @@
+// sciplot - a modern C++ scientific plotting library powered by gnuplot
+// https://github.com/sciplot/sciplot
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+// Copyright (c) 2018-2021 Allan Leal, Bim Overbohm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// sciplot includes
+#include <sciplot/sciplot.hpp>
+using namespace sciplot;
+
+int main(int argc, char** argv)
+{
+    // Create a vector with values from 0 to 10 divided into 100 uniform intervals for the x-axis
+    Vec x = linspace(1, 12, 100);
+
+    // Create a Plot object
+    Plot plot;
+
+    // Set the x and y labels
+    plot.xlabel("x");
+    plot.ylabel("y");
+
+    // Set the x and y ranges
+    plot.xrange(1, 12);
+    plot.yrange(2, 4096);
+
+    // Set the legend to be on the bottom along the horizontal
+    plot.legend()
+        .atOutsideBottom()
+        .displayHorizontal()
+        .displayExpandWidthBy(2);
+
+    plot.ytics().logscale(2);
+
+    // Plot 2^x
+    plot.drawCurve(x, std::pow(2.0, x))
+        .label("2^x");
+
+    // Show the plot in a pop-up window
+    plot.size(749, 749);
+    plot.show();
+
+    // Save the plot to a PDF file
+    plot.save("example-logarithmic-axes.pdf");
+}

--- a/sciplot/specs/TicsSpecs.hpp
+++ b/sciplot/specs/TicsSpecs.hpp
@@ -27,10 +27,11 @@
 
 // sciplot includes
 #include <sciplot/Default.hpp>
-#include <sciplot/specs/TicsSpecsBaseOf.hpp>
 #include <sciplot/Utils.hpp>
+#include <sciplot/specs/TicsSpecsBaseOf.hpp>
 
-namespace sciplot {
+namespace sciplot
+{
 
 /// The class used to specify options for tics.
 class TicsSpecs : public TicsSpecsBaseOf<TicsSpecs>
@@ -54,7 +55,7 @@ class TicsSpecs : public TicsSpecsBaseOf<TicsSpecs>
 };
 
 inline TicsSpecs::TicsSpecs()
-: TicsSpecsBaseOf<TicsSpecs>()
+    : TicsSpecsBaseOf<TicsSpecs>()
 {
     stackFront();
 }
@@ -75,7 +76,7 @@ inline auto TicsSpecs::repr() const -> std::string
 {
     const auto baserepr = TicsSpecsBaseOf<TicsSpecs>::repr();
 
-    if(isHidden())
+    if (isHidden())
         return baserepr;
 
     std::stringstream ss;

--- a/sciplot/specs/TicsSpecsBaseOf.hpp
+++ b/sciplot/specs/TicsSpecsBaseOf.hpp
@@ -27,12 +27,13 @@
 
 // sciplot includes
 #include <sciplot/Default.hpp>
+#include <sciplot/Utils.hpp>
 #include <sciplot/specs/OffsetSpecsOf.hpp>
 #include <sciplot/specs/ShowSpecsOf.hpp>
 #include <sciplot/specs/TextSpecsOf.hpp>
-#include <sciplot/Utils.hpp>
 
-namespace sciplot {
+namespace sciplot
+{
 
 /// The class used to attach common tic options to a type that also specifies tic options.
 template <typename DerivedSpecs>
@@ -49,7 +50,7 @@ class TicsSpecsBaseOf : public TextSpecsOf<DerivedSpecs>, public OffsetSpecsOf<D
     auto alongBorder() -> DerivedSpecs&;
 
     /// Set the tics to be mirrored on the opposite border if `true`.
-    auto mirror(bool value=true) -> DerivedSpecs&;
+    auto mirror(bool value = true) -> DerivedSpecs&;
 
     /// Set the tics to be displayed inside the graph.
     auto insideGraph() -> DerivedSpecs&;
@@ -58,7 +59,7 @@ class TicsSpecsBaseOf : public TextSpecsOf<DerivedSpecs>, public OffsetSpecsOf<D
     auto outsideGraph() -> DerivedSpecs&;
 
     /// Set the tics to be rotated by 90 degrees if `true`.
-    auto rotate(bool value=true) -> DerivedSpecs&;
+    auto rotate(bool value = true) -> DerivedSpecs&;
 
     /// Set the tics to be rotated by given degrees.
     auto rotateBy(double degrees) -> DerivedSpecs&;
@@ -74,6 +75,9 @@ class TicsSpecsBaseOf : public TextSpecsOf<DerivedSpecs>, public OffsetSpecsOf<D
 
     /// Set the format of the tics using a format expression (`"%.2f"`)
     auto format(std::string fmt) -> DerivedSpecs&;
+
+    /// Set logarithmic scale with base for an axis.
+    auto logscale(int base = 10) -> DerivedSpecs&;
 
     /// Convert this TicsSpecsBaseOf object into a gnuplot formatted string.
     auto repr() const -> std::string;
@@ -102,6 +106,9 @@ class TicsSpecsBaseOf : public TextSpecsOf<DerivedSpecs>, public OffsetSpecsOf<D
 
     /// The scale of the minor tics.
     double m_scaleminor = 1.0;
+
+    /// Logarithmic scaling base settings for the axis.
+    std::string m_logscaleBase;
 };
 
 template <typename DerivedSpecs>
@@ -192,6 +199,13 @@ auto TicsSpecsBaseOf<DerivedSpecs>::format(std::string fmt) -> DerivedSpecs&
 }
 
 template <typename DerivedSpecs>
+auto TicsSpecsBaseOf<DerivedSpecs>::logscale(int base) -> DerivedSpecs&
+{
+    m_logscaleBase = std::to_string(base);
+    return static_cast<DerivedSpecs&>(*this);
+}
+
+template <typename DerivedSpecs>
 auto TicsSpecsBaseOf<DerivedSpecs>::repr() const -> std::string
 {
     return repr("");
@@ -201,11 +215,16 @@ template <typename DerivedSpecs>
 auto TicsSpecsBaseOf<DerivedSpecs>::repr(std::string axis) const -> std::string
 {
     const auto show = ShowSpecsOf<DerivedSpecs>::repr();
-    if(show == "no")
+    if (show == "no")
         return "unset " + axis + "tics";
 
     std::stringstream ss;
-    ss << "set " + axis + "tics" << " ";
+    if (!m_logscaleBase.empty())
+    {
+        ss << "set logscale " + axis + " " + m_logscaleBase + "\n";
+    }
+    ss << "set " + axis + "tics"
+       << " ";
     ss << m_along << " ";
     ss << m_mirror << " ";
     ss << m_inout << " ";

--- a/sciplot/specs/TicsSpecsMajor.hpp
+++ b/sciplot/specs/TicsSpecsMajor.hpp
@@ -29,10 +29,11 @@
 #include <vector>
 
 // sciplot includes
-#include <sciplot/specs/TicsSpecsBaseOf.hpp>
 #include <sciplot/Utils.hpp>
+#include <sciplot/specs/TicsSpecsBaseOf.hpp>
 
-namespace sciplot {
+namespace sciplot
+{
 
 /// The class used to specify options for major tics of a specific axis.
 class TicsSpecsMajor : public TicsSpecsBaseOf<TicsSpecsMajor>
@@ -68,9 +69,6 @@ class TicsSpecsMajor : public TicsSpecsBaseOf<TicsSpecsMajor>
     /// Add more tics to be displayed with given tic values and corresponding labels.
     auto add(const std::vector<double>& values, const std::vector<std::string>& labels) -> TicsSpecsMajor&;
 
-    /// Set log scale for the tics.
-    auto logscale(bool value=true) -> TicsSpecsMajor&;
-
     /// Convert this TicsSpecsMajor object into a gnuplot formatted string.
     auto repr() const -> std::string;
 
@@ -92,16 +90,14 @@ class TicsSpecsMajor : public TicsSpecsBaseOf<TicsSpecsMajor>
 
     /// The extra values/labels of the tics to be displayed.
     std::string m_add;
-
-    /// The log scale option for the tics.
-    std::string m_logscale;
 };
 
 inline TicsSpecsMajor::TicsSpecsMajor(std::string axis)
-: TicsSpecsBaseOf<TicsSpecsMajor>(), m_axis(axis)
+    : TicsSpecsBaseOf<TicsSpecsMajor>(), m_axis(axis)
 {
-    if(axis.empty())
-        throw std::runtime_error("You have provided an empty string "
+    if (axis.empty())
+        throw std::runtime_error(
+            "You have provided an empty string "
             "in `axis` argument of constructor TicsSpecsMajor(axis).");
 }
 
@@ -138,8 +134,8 @@ inline auto TicsSpecsMajor::end(double value) -> TicsSpecsMajor&
 
 inline auto TicsSpecsMajor::interval(double start, double increment, double end) -> TicsSpecsMajor&
 {
-    if(increment <= 0.0) throw std::runtime_error("The `increment` argument in method TicsSpecsMajor::interval must be positive.");
-    if(end <= start) throw std::runtime_error("The `end` argument in method TicsSpecsMajor::interval must be greater than `start`.");
+    if (increment <= 0.0) throw std::runtime_error("The `increment` argument in method TicsSpecsMajor::interval must be positive.");
+    if (end <= start) throw std::runtime_error("The `end` argument in method TicsSpecsMajor::interval must be greater than `start`.");
     std::stringstream ss;
     ss << start << ", " << increment << ", " << end;
     m_at = ss.str();
@@ -150,7 +146,7 @@ inline auto TicsSpecsMajor::at(const std::vector<double>& values) -> TicsSpecsMa
 {
     std::stringstream ss;
     ss << "(";
-    for(auto i = 0; i < values.size(); ++i)
+    for (auto i = 0; i < values.size(); ++i)
         ss << (i == 0 ? "" : ", ") << values[i];
     ss << ")";
     m_at = ss.str();
@@ -161,7 +157,7 @@ inline auto TicsSpecsMajor::at(const std::vector<double>& values, const std::vec
 {
     std::stringstream ss;
     ss << "(";
-    for(auto i = 0; i < values.size(); ++i)
+    for (auto i = 0; i < values.size(); ++i)
         ss << (i == 0 ? "" : ", ") << "'" << labels[i] << "' " << values[i];
     ss << ")";
     m_at = ss.str();
@@ -172,7 +168,7 @@ inline auto TicsSpecsMajor::add(const std::vector<double>& values) -> TicsSpecsM
 {
     std::stringstream ss;
     ss << "add (";
-    for(auto i = 0; i < values.size(); ++i)
+    for (auto i = 0; i < values.size(); ++i)
         ss << (i == 0 ? "" : ", ") << values[i];
     ss << ")";
     m_add = ss.str();
@@ -183,16 +179,10 @@ inline auto TicsSpecsMajor::add(const std::vector<double>& values, const std::ve
 {
     std::stringstream ss;
     ss << "add (";
-    for(auto i = 0; i < values.size(); ++i)
+    for (auto i = 0; i < values.size(); ++i)
         ss << (i == 0 ? "" : ", ") << "'" << labels[i] << "' " << values[i];
     ss << ")";
     m_add = ss.str();
-    return *this;
-}
-
-inline auto TicsSpecsMajor::logscale(bool value) -> TicsSpecsMajor&
-{
-    m_logscale = value ? "logscale" : "";
     return *this;
 }
 
@@ -200,21 +190,20 @@ inline auto TicsSpecsMajor::repr() const -> std::string
 {
     const auto baserepr = TicsSpecsBaseOf<TicsSpecsMajor>::repr(m_axis);
 
-    if(isHidden())
+    if (isHidden())
         return baserepr;
 
-    if(m_start.size() && m_increment.empty())
+    if (m_start.size() && m_increment.empty())
         throw std::runtime_error("You have called method TicsSpecsMajor::start but not TicsSpecsMajor::increment.");
-    if(m_end.size() && m_increment.empty())
+    if (m_end.size() && m_increment.empty())
         throw std::runtime_error("You have called method TicsSpecsMajor::end but not TicsSpecsMajor::increment.");
-    if(m_end.size() && m_start.empty())
+    if (m_end.size() && m_start.empty())
         throw std::runtime_error("You have called method TicsSpecsMajor::end but not TicsSpecsMajor::start.");
 
     std::stringstream ss;
     ss << baserepr << " ";
     ss << m_at << " ";
     ss << m_add << " ";
-    ss << m_logscale << " ";
     return internal::removeExtraWhitespaces(ss.str());
 }
 

--- a/tests/TicsSpecsMajor.test.cxx
+++ b/tests/TicsSpecsMajor.test.cxx
@@ -41,98 +41,101 @@ TEST_CASE("TicsSpecsMajor", "[specs]")
     default_xtics.scaleMinorBy(internal::DEFAULT_TICS_SCALE_MINOR_BY);
 
     auto xtics = TicsSpecsMajor("x");
-    CHECK( xtics.repr() == default_xtics.repr() );
+    CHECK(xtics.repr() == default_xtics.repr());
 
     xtics.alongAxis();
-    CHECK( xtics.repr() == "set xtics axis nomirror out scale 0.5,0.25 norotate enhanced textcolor '#404040'");
+    CHECK(xtics.repr() == "set xtics axis nomirror out scale 0.5,0.25 norotate enhanced textcolor '#404040'");
 
     xtics.alongBorder();
-    CHECK( xtics.repr() == "set xtics border nomirror out scale 0.5,0.25 norotate enhanced textcolor '#404040'");
+    CHECK(xtics.repr() == "set xtics border nomirror out scale 0.5,0.25 norotate enhanced textcolor '#404040'");
 
     xtics.mirror();
-    CHECK( xtics.repr() == "set xtics border mirror out scale 0.5,0.25 norotate enhanced textcolor '#404040'");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 0.5,0.25 norotate enhanced textcolor '#404040'");
 
     xtics.insideGraph();
-    CHECK( xtics.repr() == "set xtics border mirror in scale 0.5,0.25 norotate enhanced textcolor '#404040'");
+    CHECK(xtics.repr() == "set xtics border mirror in scale 0.5,0.25 norotate enhanced textcolor '#404040'");
 
     xtics.outsideGraph();
-    CHECK( xtics.repr() == "set xtics border mirror out scale 0.5,0.25 norotate enhanced textcolor '#404040'");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 0.5,0.25 norotate enhanced textcolor '#404040'");
 
     xtics.rotate();
-    CHECK( xtics.repr() == "set xtics border mirror out scale 0.5,0.25 rotate enhanced textcolor '#404040'");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 0.5,0.25 rotate enhanced textcolor '#404040'");
 
     xtics.rotateBy(42);
-    CHECK( xtics.repr() == "set xtics border mirror out scale 0.5,0.25 rotate by 42 enhanced textcolor '#404040'");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 0.5,0.25 rotate by 42 enhanced textcolor '#404040'");
 
     xtics.scaleBy(1.2);
-    CHECK( xtics.repr() == "set xtics border mirror out scale 1.2,0.25 rotate by 42 enhanced textcolor '#404040'");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 1.2,0.25 rotate by 42 enhanced textcolor '#404040'");
 
     xtics.scaleMajorBy(5.6);
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,0.25 rotate by 42 enhanced textcolor '#404040'");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 5.6,0.25 rotate by 42 enhanced textcolor '#404040'");
 
     xtics.scaleMinorBy(7.9);
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040'");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040'");
 
     xtics.format("%4.2f");
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f'");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f'");
 
     xtics.increment(1.2345);
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' 1.2345");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' 1.2345");
 
     xtics.start(0.345);
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' 0.345, 1.2345");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' 0.345, 1.2345");
 
     xtics.end(5.652);
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' 0.345, 1.2345, 5.652");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' 0.345, 1.2345, 5.652");
 
     xtics.interval(0.234, 0.899, 3.45);
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' 0.234, 0.899, 3.45");
+    CHECK(xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' 0.234, 0.899, 3.45");
 
-    xtics.at({ 0.1, 0.2, 0.3, 0.4 });
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' (0.1, 0.2, 0.3, 0.4)");
+    xtics.at({0.1, 0.2, 0.3, 0.4});
+    CHECK(xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' (0.1, 0.2, 0.3, 0.4)");
 
-    xtics.at({ 0.1, 0.2, 0.3, 0.4 }, { "A", "", "C", "F" });
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' ('A' 0.1, '' 0.2, 'C' 0.3, 'F' 0.4)");
+    xtics.at({0.1, 0.2, 0.3, 0.4}, {"A", "", "C", "F"});
+    CHECK(xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' ('A' 0.1, '' 0.2, 'C' 0.3, 'F' 0.4)");
 
-    xtics.add({ 1.1, 1.2, 1.3, 1.4 });
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' ('A' 0.1, '' 0.2, 'C' 0.3, 'F' 0.4) add (1.1, 1.2, 1.3, 1.4)");
+    xtics.add({1.1, 1.2, 1.3, 1.4});
+    CHECK(xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' ('A' 0.1, '' 0.2, 'C' 0.3, 'F' 0.4) add (1.1, 1.2, 1.3, 1.4)");
 
-    xtics.add({ 2.1, 2.2, 2.3, 2.4 }, { "Z", "U", "V", "X" });
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' ('A' 0.1, '' 0.2, 'C' 0.3, 'F' 0.4) add ('Z' 2.1, 'U' 2.2, 'V' 2.3, 'X' 2.4)");
+    xtics.add({2.1, 2.2, 2.3, 2.4}, {"Z", "U", "V", "X"});
+    CHECK(xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' ('A' 0.1, '' 0.2, 'C' 0.3, 'F' 0.4) add ('Z' 2.1, 'U' 2.2, 'V' 2.3, 'X' 2.4)");
 
     xtics.logscale();
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' ('A' 0.1, '' 0.2, 'C' 0.3, 'F' 0.4) add ('Z' 2.1, 'U' 2.2, 'V' 2.3, 'X' 2.4) logscale");
+    CHECK(xtics.repr() == "set logscale x 10\nset xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' ('A' 0.1, '' 0.2, 'C' 0.3, 'F' 0.4) add ('Z' 2.1, 'U' 2.2, 'V' 2.3, 'X' 2.4)");
+
+    xtics.logscale(2);
+    CHECK(xtics.repr() == "set logscale x 2\nset xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' ('A' 0.1, '' 0.2, 'C' 0.3, 'F' 0.4) add ('Z' 2.1, 'U' 2.2, 'V' 2.3, 'X' 2.4)");
 
     xtics.automatic();
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' add ('Z' 2.1, 'U' 2.2, 'V' 2.3, 'X' 2.4) logscale");
+    CHECK(xtics.repr() == "set logscale x 2\nset xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' '%4.2f' add ('Z' 2.1, 'U' 2.2, 'V' 2.3, 'X' 2.4)");
 
     xtics.fontName("Arial");
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' font 'Arial,' '%4.2f' add ('Z' 2.1, 'U' 2.2, 'V' 2.3, 'X' 2.4) logscale");
+    CHECK(xtics.repr() == "set logscale x 2\nset xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' font 'Arial,' '%4.2f' add ('Z' 2.1, 'U' 2.2, 'V' 2.3, 'X' 2.4)");
 
     xtics.fontSize(16);
-    CHECK( xtics.repr() == "set xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' font 'Arial,16' '%4.2f' add ('Z' 2.1, 'U' 2.2, 'V' 2.3, 'X' 2.4) logscale");
+    CHECK(xtics.repr() == "set logscale x 2\nset xtics border mirror out scale 5.6,7.9 rotate by 42 enhanced textcolor '#404040' font 'Arial,16' '%4.2f' add ('Z' 2.1, 'U' 2.2, 'V' 2.3, 'X' 2.4)");
 
     xtics.automatic();
     xtics.start(1.0);
-    CHECK_THROWS( xtics.repr() ); // method start has been called, but not method increment
+    CHECK_THROWS(xtics.repr()); // method start has been called, but not method increment
 
     xtics.automatic();
     xtics.end(2.0);
-    CHECK_THROWS( xtics.repr() ); // method end has been called, but not methods start and increment
+    CHECK_THROWS(xtics.repr()); // method end has been called, but not methods start and increment
 
     xtics.automatic();
     xtics.start(1.0);
     xtics.end(2.0);
-    CHECK_THROWS( xtics.repr() ); // method end has been called, but not method increment
+    CHECK_THROWS(xtics.repr()); // method end has been called, but not method increment
 
     xtics.automatic();
     xtics.start(1.0);
     xtics.end(2.0);
     xtics.increment(0.1);
-    CHECK_NOTHROW( xtics.repr() ); // methods start, increment and end have been called - OK!
+    CHECK_NOTHROW(xtics.repr()); // methods start, increment and end have been called - OK!
 
-    CHECK_THROWS( TicsSpecsMajor("") ); // constructor TicsSpecsMajor has been called with empty string
+    CHECK_THROWS(TicsSpecsMajor("")); // constructor TicsSpecsMajor has been called with empty string
 
     xtics.hide();
-    CHECK( xtics.repr() == "unset xtics" );
+    CHECK(xtics.repr() == "unset xtics");
 }


### PR DESCRIPTION
Not sure if this is correct. It does a `set logscale <AXIS> <BASE>\n` before the x/y/ztics settings. Not sure if a `unset logscale <AXIS>` is needed either...
Note that the logscale() function was removed from TickSpecsMajor and added to the Base class instead.