### PR TITLE
Refactor plots

### DIFF
--- a/sciplot/Figure.hpp
+++ b/sciplot/Figure.hpp
@@ -37,17 +37,17 @@ namespace sciplot
 {
 
 /// The auxiliary type to represent either a 2D or 3D plot.
-using PlotXD = std::variant<Plot, Plot3D>;
+using PlotVariant = std::variant<Plot, Plot3D>;
 
 /// The class used to create multiple plots in one canvas.
 class Figure
 {
   public:
     /// Construct a Figure object with given plots.
-    Figure(const std::initializer_list<std::initializer_list<PlotXD>>& plots);
+    Figure(const std::initializer_list<std::initializer_list<PlotVariant>>& plots);
 
     /// Construct a Figure object with given plots.
-    Figure(const std::vector<std::vector<PlotXD>>& plots);
+    Figure(const std::vector<std::vector<PlotVariant>>& plots);
 
     /// Toggle automatic cleaning of temporary files (enabled by default). Pass false if you want to keep your script / data files.
     /// Call cleanup() to remove those files manually.
@@ -122,13 +122,13 @@ class Figure
     std::string m_scriptfilename;
 
     /// All the plots that have been added to the figure
-    std::vector<std::vector<PlotXD>> m_plots;
+    std::vector<std::vector<PlotVariant>> m_plots;
 };
 
 // Initialize the counter of plot objects
 inline std::size_t Figure::m_counter = 0;
 
-inline Figure::Figure(const std::initializer_list<std::initializer_list<PlotXD>>& plots)
+inline Figure::Figure(const std::initializer_list<std::initializer_list<PlotVariant>>& plots)
     : m_id(m_counter++), m_scriptfilename("multishow" + internal::str(m_id) + ".plt")
 {
     m_layoutrows = plots.size();
@@ -140,7 +140,7 @@ inline Figure::Figure(const std::initializer_list<std::initializer_list<PlotXD>>
         m_plots.emplace_back(row.begin(), row.end());
 }
 
-inline Figure::Figure(const std::vector<std::vector<PlotXD>>& plots)
+inline Figure::Figure(const std::vector<std::vector<PlotVariant>>& plots)
     : m_id(m_counter++), m_scriptfilename("multishow" + internal::str(m_id) + ".plt"), m_plots(plots)
 {
     m_layoutrows = plots.size();

--- a/sciplot/Plot.hpp
+++ b/sciplot/Plot.hpp
@@ -26,7 +26,6 @@
 #pragma once
 
 // C++ includes
-#include <memory>
 #include <sstream>
 #include <vector>
 

--- a/sciplot/Plot.hpp
+++ b/sciplot/Plot.hpp
@@ -64,14 +64,6 @@ class Plot : public PlotBase
     /// Construct a default Plot object
     Plot();
 
-    /// Set the default width of boxes in plots containing boxes (in absolute mode).
-    /// In absolute mode, a unit width is equivalent to one unit of length along the *x* axis.
-    auto boxWidthAbsolute(double val) -> void;
-
-    /// Set the default width of boxes in plots containing boxes (in relative mode).
-    /// In relative mode, a unit width is equivalent to setting the boxes side by side.
-    auto boxWidthRelative(double val) -> void;
-
     //======================================================================
     // METHODS FOR CUSTOMIZATION OF STYLES
     //======================================================================
@@ -379,7 +371,6 @@ class Plot : public PlotBase
     TicsSpecsMinor m_ztics_minor; ///< The specs for the minor ztics.
     TicsSpecsMajor m_rtics_major; ///< The specs for the major rtics.
     TicsSpecsMinor m_rtics_minor; ///< The specs for the minor rtics.
-    std::string m_boxwidth; ///< The default width of boxes in plots containing boxes without given widths.
 };
 
 inline Plot::Plot()
@@ -410,16 +401,6 @@ inline Plot::Plot()
 
     // This is needed because of how drawHistogram works. Using `with histograms` don't work as well.
     gnuplot("set style data histogram");
-}
-
-inline auto Plot::boxWidthAbsolute(double val) -> void
-{
-    m_boxwidth = internal::str(val) + " absolute";
-}
-
-inline auto Plot::boxWidthRelative(double val) -> void
-{
-    m_boxwidth = internal::str(val) + " relative";
 }
 
 //======================================================================

--- a/sciplot/Plot.hpp
+++ b/sciplot/Plot.hpp
@@ -65,68 +65,6 @@ class Plot : public PlotBase
     Plot();
 
     //======================================================================
-    // METHODS FOR CUSTOMIZATION OF STYLES
-    //======================================================================
-
-    /// Return an object that permits histogram style to be customized.
-    auto styleHistogram() -> HistogramStyleSpecs& { return m_style_histogram; }
-
-    //======================================================================
-    // METHODS FOR CUSTOMIZATION OF TICS
-    //======================================================================
-
-    /// Set the tics of the plot and return a reference to the corresponding specs object.
-    auto tics() -> TicsSpecs& { return m_tics; }
-
-    /// Return the specifications of the grid lines along major xtics on the bottom axis.
-    auto xtics() -> TicsSpecsMajor& { return xticsMajorBottom(); }
-
-    /// Return the specifications of the grid lines along major ytics on the left axis.
-    auto ytics() -> TicsSpecsMajor& { return yticsMajorLeft(); }
-
-    /// Return the specifications of the grid lines along major ztics.
-    auto ztics() -> TicsSpecsMajor& { return zticsMajor(); }
-
-    /// Return the specifications of the grid lines along major rtics.
-    auto rtics() -> TicsSpecsMajor& { return rticsMajor(); }
-
-    /// Return the specifications of the grid lines along major xtics on the bottom axis.
-    auto xticsMajorBottom() -> TicsSpecsMajor& { return m_xtics_major_bottom; }
-
-    /// Return the specifications of the grid lines along major xtics on the top axis.
-    auto xticsMajorTop() -> TicsSpecsMajor& { return m_xtics_major_top; }
-
-    /// Return the specifications of the grid lines along minor xtics on the bottom axis.
-    auto xticsMinorBottom() -> TicsSpecsMinor& { return m_xtics_minor_bottom; }
-
-    /// Return the specifications of the grid lines along minor xtics on the top axis.
-    auto xticsMinorTop() -> TicsSpecsMinor& { return m_xtics_minor_top; }
-
-    /// Return the specifications of the grid lines along major ytics on the left axis.
-    auto yticsMajorLeft() -> TicsSpecsMajor& { return m_ytics_major_left; }
-
-    /// Return the specifications of the grid lines along major ytics on the right axis.
-    auto yticsMajorRight() -> TicsSpecsMajor& { return m_ytics_major_right; }
-
-    /// Return the specifications of the grid lines along minor ytics on the left axis.
-    auto yticsMinorLeft() -> TicsSpecsMinor& { return m_ytics_minor_left; }
-
-    /// Return the specifications of the grid lines along minor ytics on the right axis.
-    auto yticsMinorRight() -> TicsSpecsMinor& { return m_ytics_minor_right; }
-
-    /// Return the specifications of the grid lines along major ztics.
-    auto zticsMajor() -> TicsSpecsMajor& { return m_ztics_major; }
-
-    /// Return the specifications of the grid lines along minor ztics.
-    auto zticsMinor() -> TicsSpecsMinor& { return m_ztics_minor; }
-
-    /// Return the specifications of the grid lines along minor rtics.
-    auto rticsMajor() -> TicsSpecsMajor& { return m_rtics_major; }
-
-    /// Return the specifications of the grid lines along minor rtics.
-    auto rticsMinor() -> TicsSpecsMinor& { return m_rtics_minor; }
-
-    //======================================================================
     // METHODS FOR DRAWING PLOT ELEMENTS
     //======================================================================
     /// Draw plot object with given style and given vectors (e.g., `plot.draw("lines", x, y)`).
@@ -355,52 +293,11 @@ class Plot : public PlotBase
 
     /// Convert this plot object into a gnuplot formatted string.
     auto repr() const -> std::string override;
-
-  private:
-    HistogramStyleSpecs m_style_histogram; ///< The specs for the histogram style of the plot.
-    TicsSpecs m_tics; ///< The specs of the tics of the plot
-    TicsSpecsMajor m_xtics_major_bottom; ///< The specs for the major xtics at the bottom.
-    TicsSpecsMajor m_xtics_major_top; ///< The specs for the major xtics at the top.
-    TicsSpecsMinor m_xtics_minor_bottom; ///< The specs for the minor xtics at the bottom.
-    TicsSpecsMinor m_xtics_minor_top; ///< The specs for the minor xtics at the top.
-    TicsSpecsMajor m_ytics_major_left; ///< The specs for the major ytics at the left.
-    TicsSpecsMajor m_ytics_major_right; ///< The specs for the major ytics at the right.
-    TicsSpecsMinor m_ytics_minor_left; ///< The specs for the minor ytics at the left.
-    TicsSpecsMinor m_ytics_minor_right; ///< The specs for the minor ytics at the right.
-    TicsSpecsMajor m_ztics_major; ///< The specs for the major ztics.
-    TicsSpecsMinor m_ztics_minor; ///< The specs for the minor ztics.
-    TicsSpecsMajor m_rtics_major; ///< The specs for the major rtics.
-    TicsSpecsMinor m_rtics_minor; ///< The specs for the minor rtics.
 };
 
 inline Plot::Plot()
-    : PlotBase(), m_xtics_major_bottom("x"), m_xtics_major_top("x2"), m_xtics_minor_bottom("x"), m_xtics_minor_top("x2"), m_ytics_major_left("y"), m_ytics_major_right("y2"), m_ytics_minor_left("y"), m_ytics_minor_right("y2"), m_ztics_major("z"), m_ztics_minor("z"), m_rtics_major("r"), m_rtics_minor("r")
+    : PlotBase()
 {
-    // Show only major and minor xtics and ytics
-    xticsMajorBottom().show();
-    xticsMinorBottom().show();
-    yticsMajorLeft().show();
-    yticsMinorLeft().show();
-
-    // Hide all other tics
-    xticsMajorTop().hide();
-    xticsMinorTop().hide();
-    yticsMajorRight().hide();
-    yticsMinorRight().hide();
-    zticsMajor().hide();
-    zticsMinor().hide();
-    rticsMajor().hide();
-    rticsMinor().hide();
-
-    // Default options for fill style
-    styleFill().solid();
-    styleFill().borderHide();
-
-    // Set all other default options
-    boxWidthRelative(internal::DEFAULT_FIGURE_BOXWIDTH_RELATIVE);
-
-    // This is needed because of how drawHistogram works. Using `with histograms` don't work as well.
-    gnuplot("set style data histogram");
 }
 
 //======================================================================

--- a/sciplot/Plot.hpp
+++ b/sciplot/Plot.hpp
@@ -26,6 +26,7 @@
 #pragma once
 
 // C++ includes
+#include <memory>
 #include <sstream>
 #include <vector>
 
@@ -57,20 +58,11 @@ namespace sciplot
 class Plot : public PlotBase
 {
   public:
+    /// Shared plot object
+    using SPtr = std::shared_ptr<Plot>;
+
     /// Construct a default Plot object
     Plot();
-
-    /// Set the label of the x-axis and return a reference to the corresponding specs object.
-    auto xlabel(const std::string& label) -> AxisLabelSpecs&;
-
-    /// Set the label of the y-axis and return a reference to the corresponding specs object.
-    auto ylabel(const std::string& label) -> AxisLabelSpecs&;
-
-    /// Set the x-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
-    auto xrange(const StringOrDouble& min, const StringOrDouble& max) -> void;
-
-    /// Set the y-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
-    auto yrange(const StringOrDouble& min, const StringOrDouble& max) -> void;
 
     /// Set the default width of boxes in plots containing boxes (in absolute mode).
     /// In absolute mode, a unit width is equivalent to one unit of length along the *x* axis.
@@ -373,8 +365,6 @@ class Plot : public PlotBase
     auto repr() const -> std::string override;
 
   private:
-    std::string m_xrange; ///< The x-range of the plot as a gnuplot formatted string (e.g., "set xrange [0:1]")
-    std::string m_yrange; ///< The y-range of the plot as a gnuplot formatted string (e.g., "set yrange [0:1]")
     HistogramStyleSpecs m_style_histogram; ///< The specs for the histogram style of the plot.
     TicsSpecs m_tics; ///< The specs of the tics of the plot
     TicsSpecsMajor m_xtics_major_bottom; ///< The specs for the major xtics at the bottom.
@@ -389,15 +379,11 @@ class Plot : public PlotBase
     TicsSpecsMinor m_ztics_minor; ///< The specs for the minor ztics.
     TicsSpecsMajor m_rtics_major; ///< The specs for the major rtics.
     TicsSpecsMinor m_rtics_minor; ///< The specs for the minor rtics.
-    AxisLabelSpecs m_xlabel; ///< The label of the x-axis
-    AxisLabelSpecs m_ylabel; ///< The label of the y-axis
-    AxisLabelSpecs m_zlabel; ///< The label of the z-axis
-    AxisLabelSpecs m_rlabel; ///< The label of the r-axis
     std::string m_boxwidth; ///< The default width of boxes in plots containing boxes without given widths.
 };
 
 inline Plot::Plot()
-    : PlotBase(), m_xtics_major_bottom("x"), m_xtics_major_top("x2"), m_xtics_minor_bottom("x"), m_xtics_minor_top("x2"), m_ytics_major_left("y"), m_ytics_major_right("y2"), m_ytics_minor_left("y"), m_ytics_minor_right("y2"), m_ztics_major("z"), m_ztics_minor("z"), m_rtics_major("r"), m_rtics_minor("r"), m_xlabel("x"), m_ylabel("y"), m_zlabel("z"), m_rlabel("r")
+    : PlotBase(), m_xtics_major_bottom("x"), m_xtics_major_top("x2"), m_xtics_minor_bottom("x"), m_xtics_minor_top("x2"), m_ytics_major_left("y"), m_ytics_major_right("y2"), m_ytics_minor_left("y"), m_ytics_minor_right("y2"), m_ztics_major("z"), m_ztics_minor("z"), m_rtics_major("r"), m_rtics_minor("r")
 {
     // Show only major and minor xtics and ytics
     xticsMajorBottom().show();
@@ -424,28 +410,6 @@ inline Plot::Plot()
 
     // This is needed because of how drawHistogram works. Using `with histograms` don't work as well.
     gnuplot("set style data histogram");
-}
-
-inline auto Plot::xlabel(const std::string& label) -> AxisLabelSpecs&
-{
-    m_xlabel.text(label);
-    return m_xlabel;
-}
-
-inline auto Plot::ylabel(const std::string& label) -> AxisLabelSpecs&
-{
-    m_ylabel.text(label);
-    return m_ylabel;
-}
-
-inline auto Plot::xrange(const StringOrDouble& min, const StringOrDouble& max) -> void
-{
-    m_xrange = "[" + min.value + ":" + max.value + "]";
-}
-
-inline auto Plot::yrange(const StringOrDouble& min, const StringOrDouble& max) -> void
-{
-    m_yrange = "[" + min.value + ":" + max.value + "]";
 }
 
 inline auto Plot::boxWidthAbsolute(double val) -> void
@@ -861,7 +825,6 @@ inline auto Plot::repr() const -> std::string
     script << gnuplot::commandValueStr("set yrange", m_yrange);
     script << m_xlabel << std::endl;
     script << m_ylabel << std::endl;
-    script << m_zlabel << std::endl;
     script << m_rlabel << std::endl;
     script << m_border << std::endl;
     script << m_grid << std::endl;

--- a/sciplot/Plot.hpp
+++ b/sciplot/Plot.hpp
@@ -58,9 +58,6 @@ namespace sciplot
 class Plot : public PlotBase
 {
   public:
-    /// Shared plot object
-    using SPtr = std::shared_ptr<Plot>;
-
     /// Construct a default Plot object
     Plot();
 

--- a/sciplot/Plot3D.hpp
+++ b/sciplot/Plot3D.hpp
@@ -70,14 +70,6 @@ class Plot3D : public PlotBase
     /// Set the z-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
     auto zrange(StringOrDouble min, StringOrDouble max) -> void;
 
-    /// Set the default width of boxes in plots containing boxes (in absolute mode).
-    /// In absolute mode, a unit width is equivalent to one unit of length along the *x* axis.
-    auto boxWidthAbsolute(double val) -> void;
-
-    /// Set the default width of boxes in plots containing boxes (in relative mode).
-    /// In relative mode, a unit width is equivalent to setting the boxes side by side.
-    auto boxWidthRelative(double val) -> void;
-
     //======================================================================
     // METHODS FOR CUSTOMIZATION OF STYLES
     //======================================================================
@@ -221,7 +213,6 @@ class Plot3D : public PlotBase
     TicsSpecsMajor m_rtics_major; ///< The specs for the major rtics.
     TicsSpecsMinor m_rtics_minor; ///< The specs for the minor rtics.
     AxisLabelSpecs m_zlabel; ///< The label of the z-axis
-    std::string m_boxwidth; ///< The default width of boxes in plots containing boxes without given widths.
 };
 
 inline Plot3D::Plot3D()
@@ -263,16 +254,6 @@ inline auto Plot3D::zlabel(const std::string& label) -> AxisLabelSpecs&
 inline auto Plot3D::zrange(StringOrDouble min, StringOrDouble max) -> void
 {
     m_zrange = "[" + min.value + ":" + max.value + "]";
-}
-
-inline auto Plot3D::boxWidthAbsolute(double val) -> void
-{
-    m_boxwidth = internal::str(val) + " absolute";
-}
-
-inline auto Plot3D::boxWidthRelative(double val) -> void
-{
-    m_boxwidth = internal::str(val) + " relative";
 }
 
 //======================================================================

--- a/sciplot/Plot3D.hpp
+++ b/sciplot/Plot3D.hpp
@@ -58,9 +58,6 @@ namespace sciplot
 class Plot3D : public PlotBase
 {
   public:
-    /// Shared plot object
-    using SPtr = std::shared_ptr<Plot3D>;
-
     /// Construct a default Plot object
     Plot3D();
 

--- a/sciplot/Plot3D.hpp
+++ b/sciplot/Plot3D.hpp
@@ -26,7 +26,6 @@
 #pragma once
 
 // C++ includes
-#include <memory>
 #include <sstream>
 #include <vector>
 

--- a/sciplot/Plot3D.hpp
+++ b/sciplot/Plot3D.hpp
@@ -71,68 +71,6 @@ class Plot3D : public PlotBase
     auto zrange(StringOrDouble min, StringOrDouble max) -> void;
 
     //======================================================================
-    // METHODS FOR CUSTOMIZATION OF STYLES
-    //======================================================================
-
-    /// Return an object that permits histogram style to be customized.
-    auto styleHistogram() -> HistogramStyleSpecs& { return m_style_histogram; }
-
-    //======================================================================
-    // METHODS FOR CUSTOMIZATION OF TICS
-    //======================================================================
-
-    /// Set the tics of the plot and return a reference to the corresponding specs object.
-    auto tics() -> TicsSpecs& { return m_tics; }
-
-    /// Return the specifications of the grid lines along major xtics on the bottom axis.
-    auto xtics() -> TicsSpecsMajor& { return xticsMajorBottom(); }
-
-    /// Return the specifications of the grid lines along major ytics on the left axis.
-    auto ytics() -> TicsSpecsMajor& { return yticsMajorLeft(); }
-
-    /// Return the specifications of the grid lines along major ztics.
-    auto ztics() -> TicsSpecsMajor& { return zticsMajor(); }
-
-    /// Return the specifications of the grid lines along major rtics.
-    auto rtics() -> TicsSpecsMajor& { return rticsMajor(); }
-
-    /// Return the specifications of the grid lines along major xtics on the bottom axis.
-    auto xticsMajorBottom() -> TicsSpecsMajor& { return m_xtics_major_bottom; }
-
-    /// Return the specifications of the grid lines along major xtics on the top axis.
-    auto xticsMajorTop() -> TicsSpecsMajor& { return m_xtics_major_top; }
-
-    /// Return the specifications of the grid lines along minor xtics on the bottom axis.
-    auto xticsMinorBottom() -> TicsSpecsMinor& { return m_xtics_minor_bottom; }
-
-    /// Return the specifications of the grid lines along minor xtics on the top axis.
-    auto xticsMinorTop() -> TicsSpecsMinor& { return m_xtics_minor_top; }
-
-    /// Return the specifications of the grid lines along major ytics on the left axis.
-    auto yticsMajorLeft() -> TicsSpecsMajor& { return m_ytics_major_left; }
-
-    /// Return the specifications of the grid lines along major ytics on the right axis.
-    auto yticsMajorRight() -> TicsSpecsMajor& { return m_ytics_major_right; }
-
-    /// Return the specifications of the grid lines along minor ytics on the left axis.
-    auto yticsMinorLeft() -> TicsSpecsMinor& { return m_ytics_minor_left; }
-
-    /// Return the specifications of the grid lines along minor ytics on the right axis.
-    auto yticsMinorRight() -> TicsSpecsMinor& { return m_ytics_minor_right; }
-
-    /// Return the specifications of the grid lines along major ztics.
-    auto zticsMajor() -> TicsSpecsMajor& { return m_ztics_major; }
-
-    /// Return the specifications of the grid lines along minor ztics.
-    auto zticsMinor() -> TicsSpecsMinor& { return m_ztics_minor; }
-
-    /// Return the specifications of the grid lines along minor rtics.
-    auto rticsMajor() -> TicsSpecsMajor& { return m_rtics_major; }
-
-    /// Return the specifications of the grid lines along minor rtics.
-    auto rticsMinor() -> TicsSpecsMinor& { return m_rtics_minor; }
-
-    //======================================================================
     // METHODS FOR DRAWING PLOT ELEMENTS
     //======================================================================
     /// Draw plot object with given style and given vectors (e.g., `plot.draw("lines", x, y)`).
@@ -198,51 +136,12 @@ class Plot3D : public PlotBase
 
   private:
     std::string m_zrange; ///< The z-range of the plot as a gnuplot formatted string (e.g., "set yrange [0:1]")
-    HistogramStyleSpecs m_style_histogram; ///< The specs for the histogram style of the plot.
-    TicsSpecs m_tics; ///< The specs of the tics of the plot
-    TicsSpecsMajor m_xtics_major_bottom; ///< The specs for the major xtics at the bottom.
-    TicsSpecsMajor m_xtics_major_top; ///< The specs for the major xtics at the top.
-    TicsSpecsMinor m_xtics_minor_bottom; ///< The specs for the minor xtics at the bottom.
-    TicsSpecsMinor m_xtics_minor_top; ///< The specs for the minor xtics at the top.
-    TicsSpecsMajor m_ytics_major_left; ///< The specs for the major ytics at the left.
-    TicsSpecsMajor m_ytics_major_right; ///< The specs for the major ytics at the right.
-    TicsSpecsMinor m_ytics_minor_left; ///< The specs for the minor ytics at the left.
-    TicsSpecsMinor m_ytics_minor_right; ///< The specs for the minor ytics at the right.
-    TicsSpecsMajor m_ztics_major; ///< The specs for the major ztics.
-    TicsSpecsMinor m_ztics_minor; ///< The specs for the minor ztics.
-    TicsSpecsMajor m_rtics_major; ///< The specs for the major rtics.
-    TicsSpecsMinor m_rtics_minor; ///< The specs for the minor rtics.
     AxisLabelSpecs m_zlabel; ///< The label of the z-axis
 };
 
 inline Plot3D::Plot3D()
-    : PlotBase(), m_xtics_major_bottom("x"), m_xtics_major_top("x2"), m_xtics_minor_bottom("x"), m_xtics_minor_top("x2"), m_ytics_major_left("y"), m_ytics_major_right("y2"), m_ytics_minor_left("y"), m_ytics_minor_right("y2"), m_ztics_major("z"), m_ztics_minor("z"), m_rtics_major("r"), m_rtics_minor("r"), m_zlabel("z")
+    : PlotBase(), m_zlabel("z")
 {
-    // Show only major and minor xtics and ytics
-    xticsMajorBottom().show();
-    xticsMinorBottom().show();
-    yticsMajorLeft().show();
-    yticsMinorLeft().show();
-
-    // Hide all other tics
-    xticsMajorTop().hide();
-    xticsMinorTop().hide();
-    yticsMajorRight().hide();
-    yticsMinorRight().hide();
-    zticsMajor().hide();
-    zticsMinor().hide();
-    rticsMajor().hide();
-    rticsMinor().hide();
-
-    // Default options for fill style
-    styleFill().solid();
-    styleFill().borderHide();
-
-    // Set all other default options
-    boxWidthRelative(internal::DEFAULT_FIGURE_BOXWIDTH_RELATIVE);
-
-    // This is needed because of how drawHistogram works. Using `with histograms` don't work as well.
-    gnuplot("set style data histogram");
 }
 
 inline auto Plot3D::zlabel(const std::string& label) -> AxisLabelSpecs&

--- a/sciplot/Plot3D.hpp
+++ b/sciplot/Plot3D.hpp
@@ -26,6 +26,7 @@
 #pragma once
 
 // C++ includes
+#include <memory>
 #include <sstream>
 #include <vector>
 
@@ -35,9 +36,10 @@
 #include <sciplot/Enums.hpp>
 #include <sciplot/Palettes.hpp>
 #include <sciplot/PlotBase.hpp>
+#include <sciplot/StringOrDouble.hpp>
+#include <sciplot/Utils.hpp>
 #include <sciplot/specs/AxisLabelSpecs.hpp>
 #include <sciplot/specs/BorderSpecs.hpp>
-#include <sciplot/specs/DrawSpecs.hpp>
 #include <sciplot/specs/DrawSpecs.hpp>
 #include <sciplot/specs/FillStyleSpecs.hpp>
 #include <sciplot/specs/FontSpecsOf.hpp>
@@ -47,34 +49,23 @@
 #include <sciplot/specs/LineSpecsOf.hpp>
 #include <sciplot/specs/TicsSpecs.hpp>
 #include <sciplot/specs/TicsSpecsMajor.hpp>
-#include <sciplot/specs/TicsSpecsMajor.hpp>
 #include <sciplot/specs/TicsSpecsMinor.hpp>
-#include <sciplot/StringOrDouble.hpp>
-#include <sciplot/Utils.hpp>
 
-namespace sciplot {
+namespace sciplot
+{
 
 /// The class used to create a plot containing graphical elements.
 class Plot3D : public PlotBase
 {
   public:
+    /// Shared plot object
+    using SPtr = std::shared_ptr<Plot3D>;
+
     /// Construct a default Plot object
     Plot3D();
 
-    /// Set the label of the x-axis and return a reference to the corresponding specs object.
-    auto xlabel(const std::string &label) -> AxisLabelSpecs&;
-
-    /// Set the label of the y-axis and return a reference to the corresponding specs object.
-    auto ylabel(const std::string &label) -> AxisLabelSpecs&;
-
     /// Set the label of the z-axis and return a reference to the corresponding specs object.
-    auto zlabel(const std::string &label) -> AxisLabelSpecs&;
-
-    /// Set the x-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
-    auto xrange(StringOrDouble min, StringOrDouble max) -> void;
-
-    /// Set the y-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
-    auto yrange(StringOrDouble min, StringOrDouble max) -> void;
+    auto zlabel(const std::string& label) -> AxisLabelSpecs&;
 
     /// Set the z-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
     auto zrange(StringOrDouble min, StringOrDouble max) -> void;
@@ -155,7 +146,7 @@ class Plot3D : public PlotBase
     /// Draw plot object with given style and given vectors (e.g., `plot.draw("lines", x, y)`).
 
     template <typename X, typename... Vecs>
-    auto drawWithVecs(const std::string &with, const X&, const Vecs&... vecs) -> DrawSpecs&;
+    auto drawWithVecs(const std::string& with, const X&, const Vecs&... vecs) -> DrawSpecs&;
 
     /// Draw a curve with given @p x and @p y vectors.
     template <typename X, typename Y, typename Z>
@@ -186,13 +177,13 @@ class Plot3D : public PlotBase
     //======================================================================
 
     /// Draw plot object with given style and given vectors (e.g., `plot.draw("lines", x, y)`).
-    auto drawWithCols(const std::string &fname, const std::string &with, const std::vector<ColumnIndex>& cols) -> DrawSpecs&;
+    auto drawWithCols(const std::string& fname, const std::string& with, const std::vector<ColumnIndex>& cols) -> DrawSpecs&;
 
     /// Draw a curve with given values at @p xcol and @p ycol columns in file @p fname.
-    auto drawCurve(const std::string &fname, const ColumnIndex &col, const ColumnIndex &ycol) -> DrawSpecs&;
+    auto drawCurve(const std::string& fname, const ColumnIndex& col, const ColumnIndex& ycol) -> DrawSpecs&;
 
     /// Draw a curve with points with given values at @p xcol and @p ycol columns in file @p fname.
-    auto drawCurveWithPoints(const std::string &fname, const ColumnIndex &xcol, const ColumnIndex &ycol) -> DrawSpecs&;
+    auto drawCurveWithPoints(const std::string& fname, const ColumnIndex& xcol, const ColumnIndex& ycol) -> DrawSpecs&;
 
     /// Draw dots with given values at @p xcol and @p ycol columns in file @p fname.
     auto drawDots(const std::string& fname, ColumnIndex xcol, ColumnIndex ycol) -> DrawSpecs&;
@@ -214,48 +205,27 @@ class Plot3D : public PlotBase
     auto repr() const -> std::string override;
 
   private:
-    std::string m_xrange;                  ///< The x-range of the plot as a gnuplot formatted string (e.g., "set xrange [0:1]")
-    std::string m_yrange;                  ///< The y-range of the plot as a gnuplot formatted string (e.g., "set yrange [0:1]")
-    std::string m_zrange;                  ///< The z-range of the plot as a gnuplot formatted string (e.g., "set yrange [0:1]")
+    std::string m_zrange; ///< The z-range of the plot as a gnuplot formatted string (e.g., "set yrange [0:1]")
     HistogramStyleSpecs m_style_histogram; ///< The specs for the histogram style of the plot.
-    TicsSpecs m_tics;                      ///< The specs of the tics of the plot
-    TicsSpecsMajor m_xtics_major_bottom;   ///< The specs for the major xtics at the bottom.
-    TicsSpecsMajor m_xtics_major_top;      ///< The specs for the major xtics at the top.
-    TicsSpecsMinor m_xtics_minor_bottom;   ///< The specs for the minor xtics at the bottom.
-    TicsSpecsMinor m_xtics_minor_top;      ///< The specs for the minor xtics at the top.
-    TicsSpecsMajor m_ytics_major_left;     ///< The specs for the major ytics at the left.
-    TicsSpecsMajor m_ytics_major_right;    ///< The specs for the major ytics at the right.
-    TicsSpecsMinor m_ytics_minor_left;     ///< The specs for the minor ytics at the left.
-    TicsSpecsMinor m_ytics_minor_right;    ///< The specs for the minor ytics at the right.
-    TicsSpecsMajor m_ztics_major;          ///< The specs for the major ztics.
-    TicsSpecsMinor m_ztics_minor;          ///< The specs for the minor ztics.
-    TicsSpecsMajor m_rtics_major;          ///< The specs for the major rtics.
-    TicsSpecsMinor m_rtics_minor;          ///< The specs for the minor rtics.
-    AxisLabelSpecs m_xlabel;               ///< The label of the x-axis
-    AxisLabelSpecs m_ylabel;               ///< The label of the y-axis
-    AxisLabelSpecs m_zlabel;               ///< The label of the z-axis
-    AxisLabelSpecs m_rlabel;               ///< The label of the r-axis
-    std::string m_boxwidth;                ///< The default width of boxes in plots containing boxes without given widths.
+    TicsSpecs m_tics; ///< The specs of the tics of the plot
+    TicsSpecsMajor m_xtics_major_bottom; ///< The specs for the major xtics at the bottom.
+    TicsSpecsMajor m_xtics_major_top; ///< The specs for the major xtics at the top.
+    TicsSpecsMinor m_xtics_minor_bottom; ///< The specs for the minor xtics at the bottom.
+    TicsSpecsMinor m_xtics_minor_top; ///< The specs for the minor xtics at the top.
+    TicsSpecsMajor m_ytics_major_left; ///< The specs for the major ytics at the left.
+    TicsSpecsMajor m_ytics_major_right; ///< The specs for the major ytics at the right.
+    TicsSpecsMinor m_ytics_minor_left; ///< The specs for the minor ytics at the left.
+    TicsSpecsMinor m_ytics_minor_right; ///< The specs for the minor ytics at the right.
+    TicsSpecsMajor m_ztics_major; ///< The specs for the major ztics.
+    TicsSpecsMinor m_ztics_minor; ///< The specs for the minor ztics.
+    TicsSpecsMajor m_rtics_major; ///< The specs for the major rtics.
+    TicsSpecsMinor m_rtics_minor; ///< The specs for the minor rtics.
+    AxisLabelSpecs m_zlabel; ///< The label of the z-axis
+    std::string m_boxwidth; ///< The default width of boxes in plots containing boxes without given widths.
 };
 
 inline Plot3D::Plot3D()
-: PlotBase(),
-  m_xtics_major_bottom("x"),
-  m_xtics_major_top("x2"),
-  m_xtics_minor_bottom("x"),
-  m_xtics_minor_top("x2"),
-  m_ytics_major_left("y"),
-  m_ytics_major_right("y2"),
-  m_ytics_minor_left("y"),
-  m_ytics_minor_right("y2"),
-  m_ztics_major("z"),
-  m_ztics_minor("z"),
-  m_rtics_major("r"),
-  m_rtics_minor("r"),
-  m_xlabel("x"),
-  m_ylabel("y"),
-  m_zlabel("z"),
-  m_rlabel("r")
+    : PlotBase(), m_xtics_major_bottom("x"), m_xtics_major_top("x2"), m_xtics_minor_bottom("x"), m_xtics_minor_top("x2"), m_ytics_major_left("y"), m_ytics_major_right("y2"), m_ytics_minor_left("y"), m_ytics_minor_right("y2"), m_ztics_major("z"), m_ztics_minor("z"), m_rtics_major("r"), m_rtics_minor("r"), m_zlabel("z")
 {
     // Show only major and minor xtics and ytics
     xticsMajorBottom().show();
@@ -284,39 +254,16 @@ inline Plot3D::Plot3D()
     gnuplot("set style data histogram");
 }
 
-inline auto Plot3D::xlabel(const std::string &label) -> AxisLabelSpecs&
-{
-    m_xlabel.text(label);
-    return m_xlabel;
-}
-
-inline auto Plot3D::ylabel(const std::string &label) -> AxisLabelSpecs&
-{
-    m_ylabel.text(label);
-    return m_ylabel;
-}
-
-inline auto Plot3D::zlabel(const std::string &label) -> AxisLabelSpecs&
+inline auto Plot3D::zlabel(const std::string& label) -> AxisLabelSpecs&
 {
     m_zlabel.text(label);
     return m_zlabel;
-}
-
-inline auto Plot3D::xrange(StringOrDouble min, StringOrDouble max) -> void
-{
-    m_xrange = "[" + min.value + ":" + max.value + "]";
-}
-
-inline auto Plot3D::yrange(StringOrDouble min, StringOrDouble max) -> void
-{
-    m_yrange = "[" + min.value + ":" + max.value + "]";
 }
 
 inline auto Plot3D::zrange(StringOrDouble min, StringOrDouble max) -> void
 {
     m_zrange = "[" + min.value + ":" + max.value + "]";
 }
-
 
 inline auto Plot3D::boxWidthAbsolute(double val) -> void
 {
@@ -333,7 +280,7 @@ inline auto Plot3D::boxWidthRelative(double val) -> void
 //======================================================================
 
 template <typename X, typename... Vecs>
-inline auto Plot3D::drawWithVecs(const std::string&with, const X& x, const Vecs&... vecs) -> DrawSpecs&
+inline auto Plot3D::drawWithVecs(const std::string& with, const X& x, const Vecs&... vecs) -> DrawSpecs&
 {
     // Write the given vectors x and y as a new data set to the stream
     std::ostringstream datastream;
@@ -343,10 +290,11 @@ inline auto Plot3D::drawWithVecs(const std::string&with, const X& x, const Vecs&
     // Otherwise, x contain xtics strings. Set the `using` string
     // so that these are properly used as xtics.
     std::string use;
-    if constexpr(internal::isStringVector<X>) {
+    if constexpr (internal::isStringVector<X>)
+    {
         const auto nvecs = sizeof...(Vecs);
         use = "0:"; // here, column 0 means the pseudo column with numbers 0, 1, 2, 3...
-        for(auto i = 2; i <= nvecs + 1; ++i)
+        for (auto i = 2; i <= nvecs + 1; ++i)
             use += std::to_string(i) + ":"; // this constructs 0:2:3:4:
         use += "xtic(1)"; // this terminates the string with 0:2:3:4:xtic(1), and thus column 1 is used for the xtics
     }
@@ -355,7 +303,8 @@ inline auto Plot3D::drawWithVecs(const std::string&with, const X& x, const Vecs&
     m_data += datastream.str();
 
     // Draw the data saved using a data set with index `m_numdatasets`. Increase number of data sets and set the line style specification (desired behavior is 1, 2, 3 (incrementing as new lines are plotted)).
-    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(m_drawspecs.size());;
+    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(m_drawspecs.size());
+    ;
 }
 
 template <typename X, typename Y, typename Z>
@@ -399,22 +348,23 @@ inline auto Plot3D::drawHistogram(const Y& y) -> DrawSpecs&
 // METHODS FOR DRAWING PLOT ELEMENTS USING DATA FROM LOCAL FILES
 //======================================================================
 
-inline auto Plot3D::drawWithCols(const std::string &fname, const std::string &with, const std::vector<ColumnIndex>& cols) -> DrawSpecs&
+inline auto Plot3D::drawWithCols(const std::string& fname, const std::string& with, const std::vector<ColumnIndex>& cols) -> DrawSpecs&
 {
     std::string use;
-    for(auto col : cols)
+    for (auto col : cols)
         use += col.value + ":"; // e.g., "1:4:5:7:" (where 1 is x, 4 is y, 5 is ylow and 7 is yhigh for a yerrorlines plot)
     use = internal::trimright(use, ':'); // e.g., "1:4:5:7:" => "1:4:5:7"
     std::string what = "'" + fname + "'"; // e.g., "'myfile.dat'"
-    return draw(what, use, with).lineStyle(m_drawspecs.size());; // e.g., draw(what="'myfile.dat'", use="1:2", with="lines");
+    return draw(what, use, with).lineStyle(m_drawspecs.size());
+    ; // e.g., draw(what="'myfile.dat'", use="1:2", with="lines");
 }
 
-inline auto Plot3D::drawCurve(const std::string &fname, const  ColumnIndex &xcol,const  ColumnIndex &ycol) -> DrawSpecs&
+inline auto Plot3D::drawCurve(const std::string& fname, const ColumnIndex& xcol, const ColumnIndex& ycol) -> DrawSpecs&
 {
     return drawWithCols(fname, "lines", {xcol, ycol});
 }
 
-inline auto Plot3D::drawCurveWithPoints(const std::string &fname, const ColumnIndex &xcol,const  ColumnIndex &ycol) -> DrawSpecs&
+inline auto Plot3D::drawCurveWithPoints(const std::string& fname, const ColumnIndex& xcol, const ColumnIndex& ycol) -> DrawSpecs&
 {
     return drawWithCols(fname, "linespoints", {xcol, ycol});
 }
@@ -485,7 +435,7 @@ inline auto Plot3D::repr() const -> std::string
         script << "#==============================================================================" << std::endl;
         script << "# CUSTOM EXPLICIT GNUPLOT COMMANDS" << std::endl;
         script << "#==============================================================================" << std::endl;
-        for(const auto& c : m_customcmds)
+        for (const auto& c : m_customcmds)
         {
             script << c << std::endl;
         }
@@ -499,7 +449,7 @@ inline auto Plot3D::repr() const -> std::string
 
     // Write plot commands and style per plot
     const auto n = m_drawspecs.size();
-    for(std::size_t i = 0; i < n; ++i)
+    for (std::size_t i = 0; i < n; ++i)
         script << "    " << m_drawspecs[i] << (i < n - 1 ? ", \\\n" : ""); // consider indentation with 4 spaces!
 
     // Add an empty line at the end

--- a/sciplot/PlotBase.hpp
+++ b/sciplot/PlotBase.hpp
@@ -26,7 +26,6 @@
 #pragma once
 
 // C++ includes
-#include <memory>
 #include <sstream>
 #include <vector>
 

--- a/sciplot/PlotBase.hpp
+++ b/sciplot/PlotBase.hpp
@@ -106,11 +106,69 @@ class PlotBase
     auto boxWidthRelative(double val) -> void;
 
     //======================================================================
+    // METHODS FOR CUSTOMIZATION OF TICS
+    //======================================================================
+
+    /// Set the tics of the plot and return a reference to the corresponding specs object.
+    auto tics() -> TicsSpecs& { return m_tics; }
+
+    /// Return the specifications of the grid lines along major xtics on the bottom axis.
+    auto xtics() -> TicsSpecsMajor& { return xticsMajorBottom(); }
+
+    /// Return the specifications of the grid lines along major ytics on the left axis.
+    auto ytics() -> TicsSpecsMajor& { return yticsMajorLeft(); }
+
+    /// Return the specifications of the grid lines along major ztics.
+    auto ztics() -> TicsSpecsMajor& { return zticsMajor(); }
+
+    /// Return the specifications of the grid lines along major rtics.
+    auto rtics() -> TicsSpecsMajor& { return rticsMajor(); }
+
+    /// Return the specifications of the grid lines along major xtics on the bottom axis.
+    auto xticsMajorBottom() -> TicsSpecsMajor& { return m_xtics_major_bottom; }
+
+    /// Return the specifications of the grid lines along major xtics on the top axis.
+    auto xticsMajorTop() -> TicsSpecsMajor& { return m_xtics_major_top; }
+
+    /// Return the specifications of the grid lines along minor xtics on the bottom axis.
+    auto xticsMinorBottom() -> TicsSpecsMinor& { return m_xtics_minor_bottom; }
+
+    /// Return the specifications of the grid lines along minor xtics on the top axis.
+    auto xticsMinorTop() -> TicsSpecsMinor& { return m_xtics_minor_top; }
+
+    /// Return the specifications of the grid lines along major ytics on the left axis.
+    auto yticsMajorLeft() -> TicsSpecsMajor& { return m_ytics_major_left; }
+
+    /// Return the specifications of the grid lines along major ytics on the right axis.
+    auto yticsMajorRight() -> TicsSpecsMajor& { return m_ytics_major_right; }
+
+    /// Return the specifications of the grid lines along minor ytics on the left axis.
+    auto yticsMinorLeft() -> TicsSpecsMinor& { return m_ytics_minor_left; }
+
+    /// Return the specifications of the grid lines along minor ytics on the right axis.
+    auto yticsMinorRight() -> TicsSpecsMinor& { return m_ytics_minor_right; }
+
+    /// Return the specifications of the grid lines along major ztics.
+    auto zticsMajor() -> TicsSpecsMajor& { return m_ztics_major; }
+
+    /// Return the specifications of the grid lines along minor ztics.
+    auto zticsMinor() -> TicsSpecsMinor& { return m_ztics_minor; }
+
+    /// Return the specifications of the grid lines along minor rtics.
+    auto rticsMajor() -> TicsSpecsMajor& { return m_rtics_major; }
+
+    /// Return the specifications of the grid lines along minor rtics.
+    auto rticsMinor() -> TicsSpecsMinor& { return m_rtics_minor; }
+
+    //======================================================================
     // METHODS FOR CUSTOMIZATION OF STYLES
     //======================================================================
 
     /// Return an object that permits fill style to be customized.
     auto styleFill() -> FillStyleSpecs& { return m_style_fill; }
+
+    /// Return an object that permits histogram style to be customized.
+    auto styleHistogram() -> HistogramStyleSpecs& { return m_style_histogram; }
 
     //======================================================================
     // METHODS FOR DRAWING PLOT ELEMENTS
@@ -176,6 +234,20 @@ class PlotBase
     GridSpecs m_grid; ///< The vector of grid specs for the major and minor grid lines in the plot (for xtics, ytics, mxtics, etc.).
     std::string m_xrange; ///< The x-range of the plot as a gnuplot formatted string (e.g., "set xrange [0:1]")
     std::string m_yrange; ///< The y-range of the plot as a gnuplot formatted string (e.g., "set yrange [0:1]")
+    HistogramStyleSpecs m_style_histogram; ///< The specs for the histogram style of the plot.
+    TicsSpecs m_tics; ///< The specs of the tics of the plot
+    TicsSpecsMajor m_xtics_major_bottom; ///< The specs for the major xtics at the bottom.
+    TicsSpecsMajor m_xtics_major_top; ///< The specs for the major xtics at the top.
+    TicsSpecsMinor m_xtics_minor_bottom; ///< The specs for the minor xtics at the bottom.
+    TicsSpecsMinor m_xtics_minor_top; ///< The specs for the minor xtics at the top.
+    TicsSpecsMajor m_ytics_major_left; ///< The specs for the major ytics at the left.
+    TicsSpecsMajor m_ytics_major_right; ///< The specs for the major ytics at the right.
+    TicsSpecsMinor m_ytics_minor_left; ///< The specs for the minor ytics at the left.
+    TicsSpecsMinor m_ytics_minor_right; ///< The specs for the minor ytics at the right.
+    TicsSpecsMajor m_ztics_major; ///< The specs for the major ztics.
+    TicsSpecsMinor m_ztics_minor; ///< The specs for the minor ztics.
+    TicsSpecsMajor m_rtics_major; ///< The specs for the major rtics.
+    TicsSpecsMinor m_rtics_minor; ///< The specs for the minor rtics.
     AxisLabelSpecs m_xlabel; ///< The label of the x-axis
     AxisLabelSpecs m_ylabel; ///< The label of the y-axis
     AxisLabelSpecs m_rlabel; ///< The label of the r-axis
@@ -191,13 +263,33 @@ class PlotBase
 inline std::size_t PlotBase::m_counter = 0;
 
 inline PlotBase::PlotBase()
-    : m_id(m_counter++), m_scriptfilename("show" + internal::str(m_id) + ".plt"), m_datafilename("plot" + internal::str(m_id) + ".dat"), m_xlabel("x"), m_ylabel("y"), m_rlabel("r")
+    : m_id(m_counter++), m_scriptfilename("show" + internal::str(m_id) + ".plt"), m_datafilename("plot" + internal::str(m_id) + ".dat"), m_xlabel("x"), m_ylabel("y"), m_rlabel("r"), m_xtics_major_bottom("x"), m_xtics_major_top("x2"), m_xtics_minor_bottom("x"), m_xtics_minor_top("x2"), m_ytics_major_left("y"), m_ytics_major_right("y2"), m_ytics_minor_left("y"), m_ytics_minor_right("y2"), m_ztics_major("z"), m_ztics_minor("z"), m_rtics_major("r"), m_rtics_minor("r")
 {
     // Show only major and minor xtics and ytics
+    xticsMajorBottom().show();
+    xticsMinorBottom().show();
+    yticsMajorLeft().show();
+    yticsMinorLeft().show();
+
+    // Hide all other tics
+    xticsMajorTop().hide();
+    xticsMinorTop().hide();
+    yticsMajorRight().hide();
+    yticsMinorRight().hide();
+    zticsMajor().hide();
+    zticsMinor().hide();
+    rticsMajor().hide();
+    rticsMinor().hide();
 
     // Default options for fill style
     styleFill().solid();
     styleFill().borderHide();
+
+    // Set all other default options
+    boxWidthRelative(internal::DEFAULT_FIGURE_BOXWIDTH_RELATIVE);
+
+    // This is needed because of how drawHistogram works. Using `with histograms` don't work as well.
+    gnuplot("set style data histogram");
 }
 
 inline auto PlotBase::palette(const std::string& name) -> void

--- a/sciplot/PlotBase.hpp
+++ b/sciplot/PlotBase.hpp
@@ -57,9 +57,6 @@ namespace sciplot
 class PlotBase
 {
   public:
-    /// Shared plot base object
-    using SPtr = std::shared_ptr<PlotBase>;
-
     /// Construct a default Plot object
     PlotBase();
 

--- a/sciplot/PlotBase.hpp
+++ b/sciplot/PlotBase.hpp
@@ -86,16 +86,24 @@ class PlotBase
     auto grid() -> GridSpecs& { return m_grid; }
 
     /// Set the label of the x-axis and return a reference to the corresponding specs object.
-    virtual auto xlabel(const std::string& label) -> AxisLabelSpecs&;
+    auto xlabel(const std::string& label) -> AxisLabelSpecs&;
 
     /// Set the label of the y-axis and return a reference to the corresponding specs object.
-    virtual auto ylabel(const std::string& label) -> AxisLabelSpecs&;
+    auto ylabel(const std::string& label) -> AxisLabelSpecs&;
 
     /// Set the x-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
-    virtual auto xrange(const StringOrDouble& min, const StringOrDouble& max) -> void;
+    auto xrange(const StringOrDouble& min, const StringOrDouble& max) -> void;
 
     /// Set the y-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
-    virtual auto yrange(const StringOrDouble& min, const StringOrDouble& max) -> void;
+    auto yrange(const StringOrDouble& min, const StringOrDouble& max) -> void;
+
+    /// Set the default width of boxes in plots containing boxes (in absolute mode).
+    /// In absolute mode, a unit width is equivalent to one unit of length along the *x* axis.
+    auto boxWidthAbsolute(double val) -> void;
+
+    /// Set the default width of boxes in plots containing boxes (in relative mode).
+    /// In relative mode, a unit width is equivalent to setting the boxes side by side.
+    auto boxWidthRelative(double val) -> void;
 
     //======================================================================
     // METHODS FOR CUSTOMIZATION OF STYLES
@@ -171,6 +179,7 @@ class PlotBase
     AxisLabelSpecs m_xlabel; ///< The label of the x-axis
     AxisLabelSpecs m_ylabel; ///< The label of the y-axis
     AxisLabelSpecs m_rlabel; ///< The label of the r-axis
+    std::string m_boxwidth; ///< The default width of boxes in plots containing boxes without given widths.
     FillStyleSpecs m_style_fill; ///< The specs for the fill style of the plot elements in the plot that can be painted.
     std::string m_samples; ///< The number of sample points for functions
     LegendSpecs m_legend; ///< The legend specs of the plot
@@ -234,6 +243,16 @@ inline auto PlotBase::xrange(const StringOrDouble& min, const StringOrDouble& ma
 inline auto PlotBase::yrange(const StringOrDouble& min, const StringOrDouble& max) -> void
 {
     m_yrange = "[" + min.value + ":" + max.value + "]";
+}
+
+inline auto PlotBase::boxWidthAbsolute(double val) -> void
+{
+    m_boxwidth = internal::str(val) + " absolute";
+}
+
+inline auto PlotBase::boxWidthRelative(double val) -> void
+{
+    m_boxwidth = internal::str(val) + " relative";
 }
 
 //======================================================================

--- a/sciplot/PlotBase.hpp
+++ b/sciplot/PlotBase.hpp
@@ -26,6 +26,7 @@
 #pragma once
 
 // C++ includes
+#include <memory>
 #include <sstream>
 #include <vector>
 
@@ -34,9 +35,10 @@
 #include <sciplot/Default.hpp>
 #include <sciplot/Enums.hpp>
 #include <sciplot/Palettes.hpp>
+#include <sciplot/StringOrDouble.hpp>
+#include <sciplot/Utils.hpp>
 #include <sciplot/specs/AxisLabelSpecs.hpp>
 #include <sciplot/specs/BorderSpecs.hpp>
-#include <sciplot/specs/DrawSpecs.hpp>
 #include <sciplot/specs/DrawSpecs.hpp>
 #include <sciplot/specs/FillStyleSpecs.hpp>
 #include <sciplot/specs/FontSpecsOf.hpp>
@@ -46,17 +48,18 @@
 #include <sciplot/specs/LineSpecsOf.hpp>
 #include <sciplot/specs/TicsSpecs.hpp>
 #include <sciplot/specs/TicsSpecsMajor.hpp>
-#include <sciplot/specs/TicsSpecsMajor.hpp>
 #include <sciplot/specs/TicsSpecsMinor.hpp>
-#include <sciplot/StringOrDouble.hpp>
-#include <sciplot/Utils.hpp>
 
-namespace sciplot {
+namespace sciplot
+{
 
 /// The class used to create a plot containing graphical elements.
 class PlotBase
 {
   public:
+    /// Shared plot base object
+    using SPtr = std::shared_ptr<PlotBase>;
+
     /// Construct a default Plot object
     PlotBase();
 
@@ -65,13 +68,13 @@ class PlotBase
 
     /// Set the palette of colors for the plot.
     /// @param name Any palette name displayed in https://github.com/Gnuplotting/gnuplot-palettes, such as "viridis", "parula", "jet".
-    auto palette(const std::string &name) -> void;
+    auto palette(const std::string& name) -> void;
 
     /// Set the size of the plot (in unit of points, with 1 inch = 72 points).
     auto size(std::size_t width, std::size_t height) -> void;
 
     /// Set the font name for the plot (e.g., Helvetica, Georgia, Times).
-    auto fontName(const std::string &name) -> void;
+    auto fontName(const std::string& name) -> void;
 
     /// Set the font size for the plot (e.g., 10, 12, 16).
     auto fontSize(std::size_t size) -> void;
@@ -81,6 +84,18 @@ class PlotBase
 
     /// Set the grid of the plot and return a reference to the corresponding specs object.
     auto grid() -> GridSpecs& { return m_grid; }
+
+    /// Set the label of the x-axis and return a reference to the corresponding specs object.
+    virtual auto xlabel(const std::string& label) -> AxisLabelSpecs&;
+
+    /// Set the label of the y-axis and return a reference to the corresponding specs object.
+    virtual auto ylabel(const std::string& label) -> AxisLabelSpecs&;
+
+    /// Set the x-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
+    virtual auto xrange(const StringOrDouble& min, const StringOrDouble& max) -> void;
+
+    /// Set the y-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
+    virtual auto yrange(const StringOrDouble& min, const StringOrDouble& max) -> void;
 
     //======================================================================
     // METHODS FOR CUSTOMIZATION OF STYLES
@@ -107,7 +122,7 @@ class PlotBase
     auto samples(std::size_t value) -> void;
 
     /// Use this method to provide gnuplot commands to be executed before the plotting calls.
-    auto gnuplot(const std::string &command) -> void;
+    auto gnuplot(const std::string& command) -> void;
 
     /// Show the plot in a pop-up window.
     /// @note This method removes temporary files after saving if `PlotBase::autoclean(true)` (default).
@@ -118,7 +133,7 @@ class PlotBase
     /// The supported formats are: `pdf`, `eps`, `svg`, `png`, and `jpeg`.
     /// Thus, to save a plot in `pdf` format, choose a file as in `plot.pdf`.
     /// @note This method removes temporary files after saving if `PlotBase::autoclean(true)` (default).
-    auto save(const std::string &filename) const -> void;
+    auto save(const std::string& filename) const -> void;
 
     /// Write the current plot data to the data file.
     auto savePlotData() const -> void;
@@ -138,23 +153,28 @@ class PlotBase
     virtual auto repr() const -> std::string = 0;
 
   protected:
-    static std::size_t m_counter;          ///< Counter of how many plot / singleplot objects have been instanciated in the application
-    std::size_t m_id = 0;                  ///< The Plot id derived from m_counter upon construction (must be the first member due to constructor initialization order!)
-    bool m_autoclean = true;               ///< Toggle automatic cleaning of temporary files (enabled by default)
-    std::string m_palette;                 ///< The name of the gnuplot palette to be used
-    std::size_t m_width = 0;               ///< The size of the plot in x
-    std::size_t m_height = 0;              ///< The size of the plot in y
-    std::string m_scriptfilename;          ///< The name of the file where the plot commands are saved
-    std::string m_datafilename;            ///< The multi data set file where data given to plot (e.g., vectors) are saved
-    std::string m_data;                    ///< The current plot data as a string
-    std::size_t m_numdatasets = 0;         ///< The current number of data sets in the data file
-    FontSpecs m_font;                      ///< The font name and size in the plot
-    BorderSpecs m_border;                  ///< The border style of the plot
-    GridSpecs m_grid;                      ///< The vector of grid specs for the major and minor grid lines in the plot (for xtics, ytics, mxtics, etc.).
-    FillStyleSpecs m_style_fill;           ///< The specs for the fill style of the plot elements in the plot that can be painted.
-    std::string m_samples;                 ///< The number of sample points for functions
-    LegendSpecs m_legend;                  ///< The legend specs of the plot
-    std::vector<DrawSpecs> m_drawspecs;    ///< The plot specs for each call to gnuplot plot function
+    static std::size_t m_counter; ///< Counter of how many plot / singleplot objects have been instanciated in the application
+    std::size_t m_id = 0; ///< The Plot id derived from m_counter upon construction (must be the first member due to constructor initialization order!)
+    bool m_autoclean = true; ///< Toggle automatic cleaning of temporary files (enabled by default)
+    std::string m_palette; ///< The name of the gnuplot palette to be used
+    std::size_t m_width = 0; ///< The size of the plot in x
+    std::size_t m_height = 0; ///< The size of the plot in y
+    std::string m_scriptfilename; ///< The name of the file where the plot commands are saved
+    std::string m_datafilename; ///< The multi data set file where data given to plot (e.g., vectors) are saved
+    std::string m_data; ///< The current plot data as a string
+    std::size_t m_numdatasets = 0; ///< The current number of data sets in the data file
+    FontSpecs m_font; ///< The font name and size in the plot
+    BorderSpecs m_border; ///< The border style of the plot
+    GridSpecs m_grid; ///< The vector of grid specs for the major and minor grid lines in the plot (for xtics, ytics, mxtics, etc.).
+    std::string m_xrange; ///< The x-range of the plot as a gnuplot formatted string (e.g., "set xrange [0:1]")
+    std::string m_yrange; ///< The y-range of the plot as a gnuplot formatted string (e.g., "set yrange [0:1]")
+    AxisLabelSpecs m_xlabel; ///< The label of the x-axis
+    AxisLabelSpecs m_ylabel; ///< The label of the y-axis
+    AxisLabelSpecs m_rlabel; ///< The label of the r-axis
+    FillStyleSpecs m_style_fill; ///< The specs for the fill style of the plot elements in the plot that can be painted.
+    std::string m_samples; ///< The number of sample points for functions
+    LegendSpecs m_legend; ///< The legend specs of the plot
+    std::vector<DrawSpecs> m_drawspecs; ///< The plot specs for each call to gnuplot plot function
     std::vector<std::string> m_customcmds; ///< The strings containing gnuplot custom commands
 };
 
@@ -162,9 +182,7 @@ class PlotBase
 inline std::size_t PlotBase::m_counter = 0;
 
 inline PlotBase::PlotBase()
-: m_id(m_counter++),
-  m_scriptfilename("show" + internal::str(m_id) + ".plt"),
-  m_datafilename("plot" + internal::str(m_id) + ".dat")
+    : m_id(m_counter++), m_scriptfilename("show" + internal::str(m_id) + ".plt"), m_datafilename("plot" + internal::str(m_id) + ".dat"), m_xlabel("x"), m_ylabel("y"), m_rlabel("r")
 {
     // Show only major and minor xtics and ytics
 
@@ -173,7 +191,7 @@ inline PlotBase::PlotBase()
     styleFill().borderHide();
 }
 
-inline auto PlotBase::palette(const std::string &name) -> void
+inline auto PlotBase::palette(const std::string& name) -> void
 {
     m_palette = name;
 }
@@ -184,7 +202,7 @@ inline auto PlotBase::size(std::size_t width, std::size_t height) -> void
     m_height = height;
 }
 
-inline auto PlotBase::fontName(const std::string &name) -> void
+inline auto PlotBase::fontName(const std::string& name) -> void
 {
     m_font.fontName(name);
     m_legend.fontName(name);
@@ -194,6 +212,28 @@ inline auto PlotBase::fontSize(std::size_t size) -> void
 {
     m_font.fontSize(size);
     m_legend.fontSize(size);
+}
+
+inline auto PlotBase::xlabel(const std::string& label) -> AxisLabelSpecs&
+{
+    m_xlabel.text(label);
+    return m_xlabel;
+}
+
+inline auto PlotBase::ylabel(const std::string& label) -> AxisLabelSpecs&
+{
+    m_ylabel.text(label);
+    return m_ylabel;
+}
+
+inline auto PlotBase::xrange(const StringOrDouble& min, const StringOrDouble& max) -> void
+{
+    m_xrange = "[" + min.value + ":" + max.value + "]";
+}
+
+inline auto PlotBase::yrange(const StringOrDouble& min, const StringOrDouble& max) -> void
+{
+    m_yrange = "[" + min.value + ":" + max.value + "]";
 }
 
 //======================================================================
@@ -223,7 +263,7 @@ inline auto PlotBase::samples(std::size_t value) -> void
     m_samples = internal::str(value);
 }
 
-inline auto PlotBase::gnuplot(const std::string &command) -> void
+inline auto PlotBase::gnuplot(const std::string& command) -> void
 {
     m_customcmds.push_back(command);
 }
@@ -256,13 +296,13 @@ inline auto PlotBase::show() const -> void
     gnuplot::runscript(m_scriptfilename, true);
 
     // remove the temporary files if user wants to
-    if(m_autoclean)
+    if (m_autoclean)
     {
         cleanup();
     }
 }
 
-inline auto PlotBase::save(const std::string &filename) const -> void
+inline auto PlotBase::save(const std::string& filename) const -> void
 {
     // Clean the file name to prevent errors
     auto cleanedfilename = gnuplot::cleanpath(filename);
@@ -312,7 +352,7 @@ inline auto PlotBase::save(const std::string &filename) const -> void
 inline auto PlotBase::savePlotData() const -> void
 {
     // Open data file, truncate it and write all current plot data to it
-    if(!m_data.empty())
+    if (!m_data.empty())
     {
         std::ofstream data(m_datafilename);
         data << m_data;


### PR DESCRIPTION
- Renamed PlotXD to PlotVariant
- Move a lot of common functions from Plot and Plot3D to PlotBase

This should make using references to plots easier, because for most stuff we will not need to cast...