### PR TITLE
Plot reference

### DIFF
--- a/examples/example-multiplot-mixed.cpp
+++ b/examples/example-multiplot-mixed.cpp
@@ -37,9 +37,10 @@ auto createHelixPlot()
     double c = 2;
     double r = 1;
 
-    for(auto val : z) {
-        x.push_back(r*cos(val/c));
-        y.push_back(r*sin(val/c));
+    for (auto val : z)
+    {
+        x.push_back(r * cos(val / c));
+        y.push_back(r * sin(val / c));
     }
 
     // Create the 3D plot for the helix
@@ -84,11 +85,10 @@ int main(int argc, char** argv)
     Plot3D plot3 = createHelixPlot();
 
     // Use the previous plots as sub-figures in a larger 2x2 figure.
-    Figure fig = {{ plot0, plot1 },
-                  { plot2, plot3 }};
+    Figure fig = {{plot0, plot1},
+                  {plot2, plot3}};
 
     fig.size(600, 600);
-
     fig.title("Mixing 2D and 3D plots");
     fig.palette("dark2");
     fig.show();

--- a/examples/example-multiplot.cpp
+++ b/examples/example-multiplot.cpp
@@ -47,11 +47,13 @@ int main(int argc, char** argv)
     plot3.drawCurve(x, std::sqrt(x)).label("sqrt(x)");
 
     // Use the previous plots as sub-figures in a larger 2x2 figure.
-    Figure fig = {{ plot0, plot1 },
-                  { plot2, plot3 }};
+    Figure fig = {{plot0, plot1},
+                  {plot2, plot3}};
 
+    fig.size(600, 600);
     fig.title("Trigonometric Functions");
     fig.palette("dark2");
+    fig.show();
 
     // Save the figure to a PDF file
     fig.save("example-multiplot.pdf");

--- a/examples/example-plot-reference.cpp
+++ b/examples/example-plot-reference.cpp
@@ -39,10 +39,15 @@ int main(int argc, char** argv)
     Plot plot1 = plot0;
     plot1.drawCurve(x, std::cos(x)).label("cos(x)");
 
-    // Use the previous plots as sub-figures in a larger 2x2 figure.
+    // Use the previous plots as sub-figures in a larger 2x1 figure.
     Figure fig = {{plot0, plot1}};
 
+    // change plot1 - this will also change plot0
     plot1.drawCurve(x, std::sqrt(x)).label("sqrt(x)");
+
+    // get reference to plot from figure
+    auto plot2 = fig.get<Plot>(0, 0);
+    plot2.drawCurve(x, std::tan(x)).label("tan(x)");
 
     fig.size(600, 600);
     fig.title("Trigonometric Functions");

--- a/examples/example-plot-reference.cpp
+++ b/examples/example-plot-reference.cpp
@@ -3,7 +3,7 @@
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
-// Copyright (c) 2018-2021 Allan Leal
+// Copyright (c) 2018-2021 Allan Leal, Bim Overbohm
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,25 +23,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#pragma once
-
-// We check if windows.h. is already included, as this might break compilation. See: https://sciplot.github.io/known_issues/
-#ifdef _WINDOWS_
-#ifdef _MSC_VER
-#pragma message(__FILE__ "(): warning: You might run into compiler errors if windows.h is included before sciplot.hpp! See: https://sciplot.github.io/known_issues/")
-#else
-#warning You might run into compiler errors if windows.h is included before sciplot.hpp! See: https://sciplot.github.io/known_issues/
-#endif // _MSC_VER
-#endif // _WINDOWS_
-
 // sciplot includes
-#include <sciplot/Constants.hpp>
-#include <sciplot/Default.hpp>
-#include <sciplot/Enums.hpp>
-#include <sciplot/Figure.hpp>
-#include <sciplot/Palettes.hpp>
-#include <sciplot/Plot.hpp>
-#include <sciplot/Plot3D.hpp>
-#include <sciplot/StringOrDouble.hpp>
-#include <sciplot/Utils.hpp>
-#include <sciplot/Vec.hpp>
+#include <sciplot/sciplot.hpp>
+using namespace sciplot;
+
+int main(int argc, char** argv)
+{
+    // Create a vector with values from 0 to 5 divived into 200 uniform intervals for the x-axis
+    Vec x = linspace(0.0, 5.0, 200);
+
+    // Create 4 different plots
+    Plot plot0;
+    plot0.drawCurve(x, std::sin(x)).label("sin(x)");
+
+    Plot plot1 = plot0;
+    plot1.drawCurve(x, std::cos(x)).label("cos(x)");
+
+    // Use the previous plots as sub-figures in a larger 2x2 figure.
+    Figure fig = {{plot0, plot1}};
+
+    plot1.drawCurve(x, std::sqrt(x)).label("sqrt(x)");
+
+    fig.size(600, 600);
+    fig.title("Trigonometric Functions");
+    fig.palette("dark2");
+    fig.show();
+
+    // Save the figure to a PDF file
+    fig.save("example-multiplot.pdf");
+}

--- a/examples/example-sincos-functions.cpp
+++ b/examples/example-sincos-functions.cpp
@@ -27,10 +27,6 @@
 #include <sciplot/sciplot.hpp>
 using namespace sciplot;
 
-// sciplot includes
-#include <sciplot/sciplot.hpp>
-using namespace sciplot;
-
 int main(int argc, char** argv)
 {
     // Create a vector with values from 0 to 5 divived into 200 uniform intervals for the x-axis

--- a/sciplot/Figure.hpp
+++ b/sciplot/Figure.hpp
@@ -49,6 +49,11 @@ class Figure
     /// Construct a Figure object with given plots.
     Figure(const std::vector<std::vector<PlotVariant>>& plots);
 
+    /// Get reference to plot from figure
+    /// @note This will throw if the plot at (i,j) is not of PlotType!
+    template <typename PlotType>
+    auto get(std::size_t i, std::size_t j) -> PlotType&;
+
     /// Toggle automatic cleaning of temporary files (enabled by default). Pass false if you want to keep your script / data files.
     /// Call cleanup() to remove those files manually.
     auto autoclean(bool enable = true) -> void;
@@ -147,6 +152,12 @@ inline Figure::Figure(const std::vector<std::vector<PlotVariant>>& plots)
     m_layoutcols = 1;
     for (const auto& row : plots)
         m_layoutcols = std::max<decltype(m_layoutcols)>(m_layoutcols, row.size()); // m_layoutcols = max number of columns among all rows
+}
+
+template <typename PlotType>
+auto Figure::get(std::size_t i, std::size_t j) -> PlotType&
+{
+    return std::get<PlotType>(m_plots.at(j).at(i));
 }
 
 inline auto Figure::autoclean(bool enable) -> void

--- a/sciplot/IPlot.hpp
+++ b/sciplot/IPlot.hpp
@@ -1,0 +1,215 @@
+// sciplot - a modern C++ scientific plotting library powered by gnuplot
+// https://github.com/sciplot/sciplot
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+// Copyright (c) 2018-2021 Allan Leal, Bim Overbohm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+// C++ includes
+#include <sstream>
+#include <vector>
+
+// sciplot includes
+#include <sciplot/Constants.hpp>
+#include <sciplot/Default.hpp>
+#include <sciplot/Enums.hpp>
+#include <sciplot/Palettes.hpp>
+#include <sciplot/StringOrDouble.hpp>
+#include <sciplot/Utils.hpp>
+#include <sciplot/specs/AxisLabelSpecs.hpp>
+#include <sciplot/specs/BorderSpecs.hpp>
+#include <sciplot/specs/DrawSpecs.hpp>
+#include <sciplot/specs/FillStyleSpecs.hpp>
+#include <sciplot/specs/FontSpecsOf.hpp>
+#include <sciplot/specs/GridSpecs.hpp>
+#include <sciplot/specs/HistogramStyleSpecs.hpp>
+#include <sciplot/specs/LegendSpecs.hpp>
+#include <sciplot/specs/LineSpecsOf.hpp>
+#include <sciplot/specs/TicsSpecs.hpp>
+#include <sciplot/specs/TicsSpecsMajor.hpp>
+#include <sciplot/specs/TicsSpecsMinor.hpp>
+
+namespace sciplot
+{
+
+/// Interface for a plot containing graphical elements.
+class IPlot
+{
+  public:
+    /// Virtual destructor to avoid memory leaks
+    virtual ~IPlot() = default;
+
+    /// Set the palette of colors for the plot.
+    /// @param name Any palette name displayed in https://github.com/Gnuplotting/gnuplot-palettes, such as "viridis", "parula", "jet".
+    virtual auto palette(const std::string& name) -> void = 0;
+
+    /// Set the size of the plot (in unit of points, with 1 inch = 72 points).
+    virtual auto size(std::size_t width, std::size_t height) -> void = 0;
+
+    /// Set the font name for the plot (e.g., Helvetica, Georgia, Times).
+    virtual auto fontName(const std::string& name) -> void = 0;
+
+    /// Set the font size for the plot (e.g., 10, 12, 16).
+    virtual auto fontSize(std::size_t size) -> void = 0;
+
+    /// Set the border of the plot and return a reference to the corresponding specs object.
+    virtual auto border() -> BorderSpecs& = 0;
+
+    /// Set the grid of the plot and return a reference to the corresponding specs object.
+    virtual auto grid() -> GridSpecs& = 0;
+
+    /// Set the label of the x-axis and return a reference to the corresponding specs object.
+    virtual auto xlabel(const std::string& label) -> AxisLabelSpecs& = 0;
+
+    /// Set the label of the y-axis and return a reference to the corresponding specs object.
+    virtual auto ylabel(const std::string& label) -> AxisLabelSpecs& = 0;
+
+    /// Set the x-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
+    virtual auto xrange(const StringOrDouble& min, const StringOrDouble& max) -> void = 0;
+
+    /// Set the y-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
+    virtual auto yrange(const StringOrDouble& min, const StringOrDouble& max) -> void = 0;
+
+    /// Set the default width of boxes in plots containing boxes (in absolute mode).
+    /// In absolute mode, a unit width is equivalent to one unit of length along the *x* axis.
+    virtual auto boxWidthAbsolute(double val) -> void = 0;
+
+    /// Set the default width of boxes in plots containing boxes (in relative mode).
+    /// In relative mode, a unit width is equivalent to setting the boxes side by side.
+    virtual auto boxWidthRelative(double val) -> void = 0;
+
+    //======================================================================
+    // METHODS FOR CUSTOMIZATION OF TICS
+    //======================================================================
+
+    /// Set the tics of the plot and return a reference to the corresponding specs object.
+    virtual auto tics() -> TicsSpecs& = 0;
+
+    /// Return the specifications of the grid lines along major xtics on the bottom axis.
+    virtual auto xtics() -> TicsSpecsMajor& = 0;
+
+    /// Return the specifications of the grid lines along major ytics on the left axis.
+    virtual auto ytics() -> TicsSpecsMajor& = 0;
+
+    /// Return the specifications of the grid lines along major ztics.
+    virtual auto ztics() -> TicsSpecsMajor& = 0;
+
+    /// Return the specifications of the grid lines along major rtics.
+    virtual auto rtics() -> TicsSpecsMajor& = 0;
+
+    /// Return the specifications of the grid lines along major xtics on the bottom axis.
+    virtual auto xticsMajorBottom() -> TicsSpecsMajor& = 0;
+
+    /// Return the specifications of the grid lines along major xtics on the top axis.
+    virtual auto xticsMajorTop() -> TicsSpecsMajor& = 0;
+
+    /// Return the specifications of the grid lines along minor xtics on the bottom axis.
+    virtual auto xticsMinorBottom() -> TicsSpecsMinor& = 0;
+
+    /// Return the specifications of the grid lines along minor xtics on the top axis.
+    virtual auto xticsMinorTop() -> TicsSpecsMinor& = 0;
+
+    /// Return the specifications of the grid lines along major ytics on the left axis.
+    virtual auto yticsMajorLeft() -> TicsSpecsMajor& = 0;
+
+    /// Return the specifications of the grid lines along major ytics on the right axis.
+    virtual auto yticsMajorRight() -> TicsSpecsMajor& = 0;
+
+    /// Return the specifications of the grid lines along minor ytics on the left axis.
+    virtual auto yticsMinorLeft() -> TicsSpecsMinor& = 0;
+
+    /// Return the specifications of the grid lines along minor ytics on the right axis.
+    virtual auto yticsMinorRight() -> TicsSpecsMinor& = 0;
+
+    /// Return the specifications of the grid lines along major ztics.
+    virtual auto zticsMajor() -> TicsSpecsMajor& = 0;
+
+    /// Return the specifications of the grid lines along minor ztics.
+    virtual auto zticsMinor() -> TicsSpecsMinor& = 0;
+
+    /// Return the specifications of the grid lines along minor rtics.
+    virtual auto rticsMajor() -> TicsSpecsMajor& = 0;
+
+    /// Return the specifications of the grid lines along minor rtics.
+    virtual auto rticsMinor() -> TicsSpecsMinor& = 0;
+
+    //======================================================================
+    // METHODS FOR CUSTOMIZATION OF STYLES
+    //======================================================================
+
+    /// Return an object that permits fill style to be customized.
+    virtual auto styleFill() -> FillStyleSpecs& = 0;
+
+    /// Return an object that permits histogram style to be customized.
+    virtual auto styleHistogram() -> HistogramStyleSpecs& = 0;
+
+    //======================================================================
+    // METHODS FOR DRAWING PLOT ELEMENTS
+    //======================================================================
+
+    /// Draw plot object with given `what`, `using` and `with` expressions (e.g., `plot.draw("sin(x)*cos(x)", "", "linespoints")`,  (e.g., `plot.draw("file.dat", "1:2", "points")`)).
+    virtual auto draw(const std::string& what, const std::string& use, const std::string& with) -> DrawSpecs& = 0;
+
+    //======================================================================
+    // MISCElLANEOUS METHODS
+    //======================================================================
+
+    /// Set the legend of the plot and return a reference to the corresponding specs object.
+    virtual auto legend() -> LegendSpecs& = 0;
+
+    /// Set the number of sample points for analytical plots.
+    virtual auto samples(std::size_t value) -> void = 0;
+
+    /// Use this method to provide gnuplot commands to be executed before the plotting calls.
+    virtual auto gnuplot(const std::string& command) -> void = 0;
+
+    /// Show the plot in a pop-up window.
+    /// @note This method removes temporary files after saving if `PlotBase::autoclean(true)` (default).
+    virtual auto show() const -> void = 0;
+
+    /// Save the plot in a file, with its extension defining the file format.
+    /// The extension of the file name determines the file format.
+    /// The supported formats are: `pdf`, `eps`, `svg`, `png`, and `jpeg`.
+    /// Thus, to save a plot in `pdf` format, choose a file as in `plot.pdf`.
+    /// @note This method removes temporary files after saving if `PlotBase::autoclean(true)` (default).
+    virtual auto save(const std::string& filename) const -> void = 0;
+
+    /// Write the current plot data to the data file.
+    virtual auto savePlotData() const -> void = 0;
+
+    /// Toggle automatic cleaning of temporary files (enabled by default). Pass false if you want to keep your script / data files.
+    /// Call cleanup() to remove those files manually.
+    virtual auto autoclean(bool enable = true) -> void = 0;
+
+    /// Delete all files used to store plot data or scripts.
+    virtual auto cleanup() const -> void = 0;
+
+    /// Clear all draw and gnuplot commands.
+    /// @note This method leaves all other plot properties untouched.
+    virtual auto clear() -> void = 0;
+
+    /// Convert this plot object into a gnuplot formatted string.
+    virtual auto repr() const -> std::string = 0;
+};
+
+} // namespace sciplot

--- a/sciplot/IPlotImplForward.hpp
+++ b/sciplot/IPlotImplForward.hpp
@@ -1,0 +1,203 @@
+// sciplot - a modern C++ scientific plotting library powered by gnuplot
+// https://github.com/sciplot/sciplot
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+// Copyright (c) 2018-2021 Allan Leal, Bim Overbohm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+// sciplot includes
+#include <sciplot/PlotBase.hpp>
+
+namespace sciplot
+{
+
+namespace internal
+{
+
+/// This class implements the IPLot methods and forwards them through the pimpl pointer
+template <typename IMPL_CLASS>
+class IPlotImplForward : public IPlot
+{
+  public:
+    /// Construct a forwarder object
+    IPlotImplForward()
+        : m_impl(std::make_shared<IMPL_CLASS>())
+    {
+    }
+
+    /// Set the palette of colors for the plot.
+    /// @param name Any palette name displayed in https://github.com/Gnuplotting/gnuplot-palettes, such as "viridis", "parula", "jet".
+    auto palette(const std::string& name) -> void override { m_impl->palette(name); }
+
+    /// Set the size of the plot (in unit of points, with 1 inch = 72 points).
+    auto size(std::size_t width, std::size_t height) -> void override { m_impl->size(width, height); }
+
+    /// Set the font name for the plot (e.g., Helvetica, Georgia, Times).
+    auto fontName(const std::string& name) -> void override { m_impl->fontName(name); }
+
+    /// Set the font size for the plot (e.g., 10, 12, 16).
+    auto fontSize(std::size_t size) -> void override { m_impl->fontSize(size); }
+
+    /// Set the border of the plot and return a reference to the corresponding specs object.
+    auto border() -> BorderSpecs& override { return m_impl->border(); }
+
+    /// Set the grid of the plot and return a reference to the corresponding specs object.
+    auto grid() -> GridSpecs& override { return m_impl->grid(); }
+
+    /// Set the label of the x-axis and return a reference to the corresponding specs object.
+    auto xlabel(const std::string& label) -> AxisLabelSpecs& override { return m_impl->xlabel(label); }
+
+    /// Set the label of the y-axis and return a reference to the corresponding specs object.
+    auto ylabel(const std::string& label) -> AxisLabelSpecs& override { return m_impl->ylabel(label); }
+
+    /// Set the x-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
+    auto xrange(const StringOrDouble& min, const StringOrDouble& max) -> void override { m_impl->xrange(min, max); }
+
+    /// Set the y-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
+    auto yrange(const StringOrDouble& min, const StringOrDouble& max) -> void override { m_impl->yrange(min, max); }
+
+    /// Set the default width of boxes in plots containing boxes (in absolute mode).
+    /// In absolute mode, a unit width is equivalent to one unit of length along the *x* axis.
+    auto boxWidthAbsolute(double val) -> void override { m_impl->boxWidthAbsolute(val); }
+
+    /// Set the default width of boxes in plots containing boxes (in relative mode).
+    /// In relative mode, a unit width is equivalent to setting the boxes side by side.
+    auto boxWidthRelative(double val) -> void override { m_impl->boxWidthRelative(val); }
+
+    //======================================================================
+    // METHODS FOR CUSTOMIZATION OF TICS
+    //======================================================================
+
+    /// Set the tics of the plot and return a reference to the corresponding specs object.
+    auto tics() -> TicsSpecs& override { return m_impl->tics(); }
+
+    /// Return the specifications of the grid lines along major xtics on the bottom axis.
+    auto xtics() -> TicsSpecsMajor& override { return m_impl->xticsMajorBottom(); }
+
+    /// Return the specifications of the grid lines along major ytics on the left axis.
+    auto ytics() -> TicsSpecsMajor& override { return m_impl->yticsMajorLeft(); }
+
+    /// Return the specifications of the grid lines along major ztics.
+    auto ztics() -> TicsSpecsMajor& override { return m_impl->zticsMajor(); }
+
+    /// Return the specifications of the grid lines along major rtics.
+    auto rtics() -> TicsSpecsMajor& override { return m_impl->rticsMajor(); }
+
+    /// Return the specifications of the grid lines along major xtics on the bottom axis.
+    auto xticsMajorBottom() -> TicsSpecsMajor& override { return m_impl->xticsMajorBottom(); }
+
+    /// Return the specifications of the grid lines along major xtics on the top axis.
+    auto xticsMajorTop() -> TicsSpecsMajor& override { return m_impl->xticsMajorTop(); }
+
+    /// Return the specifications of the grid lines along minor xtics on the bottom axis.
+    auto xticsMinorBottom() -> TicsSpecsMinor& override { return m_impl->xticsMinorBottom(); }
+
+    /// Return the specifications of the grid lines along minor xtics on the top axis.
+    auto xticsMinorTop() -> TicsSpecsMinor& override { return m_impl->xticsMinorTop(); }
+
+    /// Return the specifications of the grid lines along major ytics on the left axis.
+    auto yticsMajorLeft() -> TicsSpecsMajor& override { return m_impl->yticsMajorLeft(); }
+
+    /// Return the specifications of the grid lines along major ytics on the right axis.
+    auto yticsMajorRight() -> TicsSpecsMajor& override { return m_impl->yticsMajorRight(); }
+
+    /// Return the specifications of the grid lines along minor ytics on the left axis.
+    auto yticsMinorLeft() -> TicsSpecsMinor& override { return m_impl->yticsMinorLeft(); }
+
+    /// Return the specifications of the grid lines along minor ytics on the right axis.
+    auto yticsMinorRight() -> TicsSpecsMinor& override { return m_impl->yticsMinorRight(); }
+
+    /// Return the specifications of the grid lines along major ztics.
+    auto zticsMajor() -> TicsSpecsMajor& override { return m_impl->zticsMajor(); }
+
+    /// Return the specifications of the grid lines along minor ztics.
+    auto zticsMinor() -> TicsSpecsMinor& override { return m_impl->zticsMinor(); }
+
+    /// Return the specifications of the grid lines along minor rtics.
+    auto rticsMajor() -> TicsSpecsMajor& override { return m_impl->rticsMajor(); }
+
+    /// Return the specifications of the grid lines along minor rtics.
+    auto rticsMinor() -> TicsSpecsMinor& { return m_impl->rticsMinor(); }
+
+    //======================================================================
+    // METHODS FOR CUSTOMIZATION OF STYLES
+    //======================================================================
+
+    /// Return an object that permits fill style to be customized.
+    auto styleFill() -> FillStyleSpecs& override { return m_impl->styleFill(); }
+
+    /// Return an object that permits histogram style to be customized.
+    auto styleHistogram() -> HistogramStyleSpecs& override { return m_impl->styleHistogram(); }
+
+    //======================================================================
+    // METHODS FOR DRAWING PLOT ELEMENTS
+    //======================================================================
+
+    /// Draw plot object with given `what`, `using` and `with` expressions (e.g., `plot.draw("sin(x)*cos(x)", "", "linespoints")`,  (e.g., `plot.draw("file.dat", "1:2", "points")`)).
+    auto draw(const std::string& what, const std::string& use, const std::string& with) -> DrawSpecs& override { return m_impl->draw(what, use, with); }
+
+    //======================================================================
+    // MISCElLANEOUS METHODS
+    //======================================================================
+
+    /// Set the legend of the plot and return a reference to the corresponding specs object.
+    auto legend() -> LegendSpecs& override { return m_impl->legend(); }
+
+    /// Set the number of sample points for analytical plots.
+    auto samples(std::size_t value) -> void override { m_impl->samples(value); }
+
+    /// Use this method to provide gnuplot commands to be executed before the plotting calls.
+    auto gnuplot(const std::string& command) -> void override { m_impl->gnuplot(command); }
+
+    /// Show the plot in a pop-up window.
+    /// @note This method removes temporary files after saving if `PlotBase::autoclean(true)` (default).
+    auto show() const -> void override { m_impl->show(); }
+
+    /// Save the plot in a file, with its extension defining the file format.
+    /// The extension of the file name determines the file format.
+    /// The supported formats are: `pdf`, `eps`, `svg`, `png`, and `jpeg`.
+    /// Thus, to save a plot in `pdf` format, choose a file as in `plot.pdf`.
+    /// @note This method removes temporary files after saving if `PlotBase::autoclean(true)` (default).
+    auto save(const std::string& filename) const -> void override { m_impl->save(filename); }
+
+    /// Write the current plot data to the data file.
+    auto savePlotData() const -> void override { m_impl->savePlotData(); }
+
+    /// Toggle automatic cleaning of temporary files (enabled by default). Pass false if you want to keep your script / data files.
+    /// Call cleanup() to remove those files manually.
+    auto autoclean(bool enable = true) -> void override { m_impl->autoclean(enable); }
+
+    /// Delete all files used to store plot data or scripts.
+    auto cleanup() const -> void override { m_impl->cleanup(); }
+
+    /// Clear all draw and gnuplot commands.
+    /// @note This method leaves all other plot properties untouched.
+    auto clear() -> void override { m_impl->clear(); }
+
+  protected:
+    std::shared_ptr<IMPL_CLASS> m_impl{};
+};
+
+} // namespace internal
+
+} // namespace sciplot

--- a/sciplot/Plot3D.hpp
+++ b/sciplot/Plot3D.hpp
@@ -3,7 +3,7 @@
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
-// Copyright (c) 2018-2021 Allan Leal
+// Copyright (c) 2018-2021 Allan Leal, Bim Overbohm
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@
 #pragma once
 
 // C++ includes
+#include <memory>
 #include <sstream>
 #include <vector>
 
@@ -33,8 +34,9 @@
 #include <sciplot/Constants.hpp>
 #include <sciplot/Default.hpp>
 #include <sciplot/Enums.hpp>
+#include <sciplot/IPlotImplForward.hpp>
 #include <sciplot/Palettes.hpp>
-#include <sciplot/PlotBase.hpp>
+#include <sciplot/Plot3DImpl.hpp>
 #include <sciplot/StringOrDouble.hpp>
 #include <sciplot/Utils.hpp>
 #include <sciplot/specs/AxisLabelSpecs.hpp>
@@ -54,12 +56,9 @@ namespace sciplot
 {
 
 /// The class used to create a plot containing graphical elements.
-class Plot3D : public PlotBase
+class Plot3D : public internal::IPlotImplForward<internal::Plot3DImpl>
 {
   public:
-    /// Construct a default Plot object
-    Plot3D();
-
     /// Set the label of the z-axis and return a reference to the corresponding specs object.
     auto zlabel(const std::string& label) -> AxisLabelSpecs&;
 
@@ -124,31 +123,21 @@ class Plot3D : public PlotBase
     auto drawHistogram(const std::string& fname, ColumnIndex ycol) -> DrawSpecs&;
 
     //======================================================================
-    // MISCElLANEOUS METHODS
+    // MISCELLANEOUS METHODS
     //======================================================================
 
     /// Convert this plot object into a gnuplot formatted string.
     auto repr() const -> std::string override;
-
-  private:
-    std::string m_zrange; ///< The z-range of the plot as a gnuplot formatted string (e.g., "set yrange [0:1]")
-    AxisLabelSpecs m_zlabel; ///< The label of the z-axis
 };
-
-inline Plot3D::Plot3D()
-    : PlotBase(), m_zlabel("z")
-{
-}
 
 inline auto Plot3D::zlabel(const std::string& label) -> AxisLabelSpecs&
 {
-    m_zlabel.text(label);
-    return m_zlabel;
+    return m_impl->zlabel(label);
 }
 
 inline auto Plot3D::zrange(StringOrDouble min, StringOrDouble max) -> void
 {
-    m_zrange = "[" + min.value + ":" + max.value + "]";
+    return m_impl->zrange(min, max);
 }
 
 //======================================================================
@@ -158,66 +147,44 @@ inline auto Plot3D::zrange(StringOrDouble min, StringOrDouble max) -> void
 template <typename X, typename... Vecs>
 inline auto Plot3D::drawWithVecs(const std::string& with, const X& x, const Vecs&... vecs) -> DrawSpecs&
 {
-    // Write the given vectors x and y as a new data set to the stream
-    std::ostringstream datastream;
-    gnuplot::writedataset(datastream, m_numdatasets, x, vecs...);
-
-    // Set the using string to "" if X is not vector of strings.
-    // Otherwise, x contain xtics strings. Set the `using` string
-    // so that these are properly used as xtics.
-    std::string use;
-    if constexpr (internal::isStringVector<X>)
-    {
-        const auto nvecs = sizeof...(Vecs);
-        use = "0:"; // here, column 0 means the pseudo column with numbers 0, 1, 2, 3...
-        for (auto i = 2; i <= nvecs + 1; ++i)
-            use += std::to_string(i) + ":"; // this constructs 0:2:3:4:
-        use += "xtic(1)"; // this terminates the string with 0:2:3:4:xtic(1), and thus column 1 is used for the xtics
-    }
-
-    // Append new data set to existing data
-    m_data += datastream.str();
-
-    // Draw the data saved using a data set with index `m_numdatasets`. Increase number of data sets and set the line style specification (desired behavior is 1, 2, 3 (incrementing as new lines are plotted)).
-    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(m_drawspecs.size());
-    ;
+    return m_impl->drawWithVecs(with, x, vecs...);
 }
 
 template <typename X, typename Y, typename Z>
 inline auto Plot3D::drawCurve(const X& x, const Y& y, const Z& z) -> DrawSpecs&
 {
-    return drawWithVecs("lines", x, y, z);
+    return m_impl->drawWithVecs("lines", x, y, z);
 }
 
 template <typename X, typename Y, typename Z>
 inline auto Plot3D::drawCurveWithPoints(const X& x, const Y& y, const Z& z) -> DrawSpecs&
 {
 
-    return drawWithVecs("linespoints", x, y, z);
+    return m_impl->drawWithVecs("linespoints", x, y, z);
 }
 
 template <typename X, typename Y, typename Z>
 inline auto Plot3D::drawDots(const X& x, const Y& y, const Z& z) -> DrawSpecs&
 {
-    return drawWithVecs("dots", x, y, z);
+    return m_impl->drawWithVecs("dots", x, y, z);
 }
 
 template <typename X, typename Y, typename Z>
 inline auto Plot3D::drawPoints(const X& x, const Y& y, const Z& z) -> DrawSpecs&
 {
-    return drawWithVecs("points", x, y, z);
+    return m_impl->drawWithVecs("points", x, y, z);
 }
 
 template <typename X, typename Y, typename Z>
 inline auto Plot3D::drawImpulses(const X& x, const Y& y, const Z& z) -> DrawSpecs&
 {
-    return drawWithVecs("impulses", x, y, z);
+    return m_impl->drawWithVecs("impulses", x, y, z);
 }
 
 template <typename Y>
 inline auto Plot3D::drawHistogram(const Y& y) -> DrawSpecs&
 {
-    return drawWithVecs("", y); // empty string because we rely on `set style data histograms` since relying `with histograms` is not working very well (e.g., empty key/lenged appearing in columnstacked mode).
+    return m_impl->drawWithVecs("", y); // empty string because we rely on `set style data histograms` since relying `with histograms` is not working very well (e.g., empty key/lenged appearing in columnstacked mode).
 }
 
 //======================================================================
@@ -226,111 +193,46 @@ inline auto Plot3D::drawHistogram(const Y& y) -> DrawSpecs&
 
 inline auto Plot3D::drawWithCols(const std::string& fname, const std::string& with, const std::vector<ColumnIndex>& cols) -> DrawSpecs&
 {
-    std::string use;
-    for (auto col : cols)
-        use += col.value + ":"; // e.g., "1:4:5:7:" (where 1 is x, 4 is y, 5 is ylow and 7 is yhigh for a yerrorlines plot)
-    use = internal::trimright(use, ':'); // e.g., "1:4:5:7:" => "1:4:5:7"
-    std::string what = "'" + fname + "'"; // e.g., "'myfile.dat'"
-    return draw(what, use, with).lineStyle(m_drawspecs.size());
-    ; // e.g., draw(what="'myfile.dat'", use="1:2", with="lines");
+    return m_impl->drawWithCols(fname, with, cols);
 }
 
 inline auto Plot3D::drawCurve(const std::string& fname, const ColumnIndex& xcol, const ColumnIndex& ycol) -> DrawSpecs&
 {
-    return drawWithCols(fname, "lines", {xcol, ycol});
+    return m_impl->drawWithCols(fname, "lines", {xcol, ycol});
 }
 
 inline auto Plot3D::drawCurveWithPoints(const std::string& fname, const ColumnIndex& xcol, const ColumnIndex& ycol) -> DrawSpecs&
 {
-    return drawWithCols(fname, "linespoints", {xcol, ycol});
+    return m_impl->drawWithCols(fname, "linespoints", {xcol, ycol});
 }
 
 inline auto Plot3D::drawDots(const std::string& fname, ColumnIndex xcol, ColumnIndex ycol) -> DrawSpecs&
 {
-    return drawWithCols(fname, "dots", {xcol, ycol});
+    return m_impl->drawWithCols(fname, "dots", {xcol, ycol});
 }
 
 inline auto Plot3D::drawPoints(const std::string& fname, ColumnIndex xcol, ColumnIndex ycol) -> DrawSpecs&
 {
-    return drawWithCols(fname, "points", {xcol, ycol});
+    return m_impl->drawWithCols(fname, "points", {xcol, ycol});
 }
 
 inline auto Plot3D::drawImpulses(const std::string& fname, ColumnIndex xcol, ColumnIndex ycol) -> DrawSpecs&
 {
-    return drawWithCols(fname, "impulses", {xcol, ycol});
+    return m_impl->drawWithCols(fname, "impulses", {xcol, ycol});
 }
 
 inline auto Plot3D::drawHistogram(const std::string& fname, ColumnIndex ycol) -> DrawSpecs&
 {
-    return drawWithCols(fname, "", {ycol});
+    return m_impl->drawWithCols(fname, "", {ycol});
 }
 
 //======================================================================
-// MISCElLANEOUS METHODS
+// MISCELLANEOUS METHODS
 //======================================================================
 
 inline auto Plot3D::repr() const -> std::string
 {
-    std::stringstream script;
-
-    // Add plot setup commands
-    script << "#==============================================================================" << std::endl;
-    script << "# SETUP COMMANDS" << std::endl;
-    script << "#==============================================================================" << std::endl;
-    script << gnuplot::commandValueStr("set xrange", m_xrange);
-    script << gnuplot::commandValueStr("set yrange", m_yrange);
-    script << gnuplot::commandValueStr("set zrange", m_zrange);
-    script << m_xlabel << std::endl;
-    script << m_ylabel << std::endl;
-    script << m_zlabel << std::endl;
-    script << m_rlabel << std::endl;
-    script << m_border << std::endl;
-    script << m_grid << std::endl;
-    script << m_style_fill << std::endl;
-    script << m_style_histogram << std::endl;
-    script << m_tics << std::endl;
-    script << m_xtics_major_bottom << std::endl;
-    script << m_xtics_major_top << std::endl;
-    script << m_xtics_minor_bottom << std::endl;
-    script << m_xtics_minor_top << std::endl;
-    script << m_ytics_major_left << std::endl;
-    script << m_ytics_major_right << std::endl;
-    script << m_ytics_minor_left << std::endl;
-    script << m_ytics_minor_right << std::endl;
-    script << m_ztics_major << std::endl;
-    script << m_ztics_minor << std::endl;
-    script << m_rtics_major << std::endl;
-    script << m_rtics_minor << std::endl;
-    script << m_legend << std::endl;
-    script << gnuplot::commandValueStr("set boxwidth", m_boxwidth);
-    script << gnuplot::commandValueStr("set samples", m_samples);
-
-    // Add custom gnuplot commands
-    if (!m_customcmds.empty())
-    {
-        script << "#==============================================================================" << std::endl;
-        script << "# CUSTOM EXPLICIT GNUPLOT COMMANDS" << std::endl;
-        script << "#==============================================================================" << std::endl;
-        for (const auto& c : m_customcmds)
-        {
-            script << c << std::endl;
-        }
-    }
-
-    // Add the actual plot commands for all drawXYZ() calls
-    script << "#==============================================================================" << std::endl;
-    script << "# PLOT COMMANDS" << std::endl;
-    script << "#==============================================================================" << std::endl;
-    script << "splot \\\n"; // use `\` to have a plot command in each individual line!
-
-    // Write plot commands and style per plot
-    const auto n = m_drawspecs.size();
-    for (std::size_t i = 0; i < n; ++i)
-        script << "    " << m_drawspecs[i] << (i < n - 1 ? ", \\\n" : ""); // consider indentation with 4 spaces!
-
-    // Add an empty line at the end
-    script << std::endl;
-    return script.str();
+    return m_impl->repr();
 }
 
 } // namespace sciplot

--- a/sciplot/Plot3DImpl.hpp
+++ b/sciplot/Plot3DImpl.hpp
@@ -1,0 +1,232 @@
+// sciplot - a modern C++ scientific plotting library powered by gnuplot
+// https://github.com/sciplot/sciplot
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+// Copyright (c) 2018-2021 Allan Leal, Bim Overbohm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+// C++ includes
+#include <sstream>
+#include <vector>
+
+// sciplot includes
+#include <sciplot/Constants.hpp>
+#include <sciplot/Default.hpp>
+#include <sciplot/Enums.hpp>
+#include <sciplot/Palettes.hpp>
+#include <sciplot/PlotBase.hpp>
+#include <sciplot/StringOrDouble.hpp>
+#include <sciplot/Utils.hpp>
+#include <sciplot/specs/AxisLabelSpecs.hpp>
+#include <sciplot/specs/BorderSpecs.hpp>
+#include <sciplot/specs/DrawSpecs.hpp>
+#include <sciplot/specs/FillStyleSpecs.hpp>
+#include <sciplot/specs/FontSpecsOf.hpp>
+#include <sciplot/specs/GridSpecs.hpp>
+#include <sciplot/specs/HistogramStyleSpecs.hpp>
+#include <sciplot/specs/LegendSpecs.hpp>
+#include <sciplot/specs/LineSpecsOf.hpp>
+#include <sciplot/specs/TicsSpecs.hpp>
+#include <sciplot/specs/TicsSpecsMajor.hpp>
+#include <sciplot/specs/TicsSpecsMinor.hpp>
+
+namespace sciplot
+{
+
+namespace internal
+{
+
+/// The class used to create a plot containing graphical elements.
+class Plot3DImpl : public PlotBase
+{
+  public:
+    /// Construct a default Plot object
+    Plot3DImpl();
+
+    /// Set the label of the z-axis and return a reference to the corresponding specs object.
+    auto zlabel(const std::string& label) -> AxisLabelSpecs&;
+
+    /// Set the z-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
+    auto zrange(StringOrDouble min, StringOrDouble max) -> void;
+
+    //======================================================================
+    // METHODS FOR DRAWING PLOT ELEMENTS
+    //======================================================================
+    /// Draw plot object with given style and given vectors (e.g., `plot.draw("lines", x, y)`).
+
+    template <typename X, typename... Vecs>
+    auto drawWithVecs(const std::string& with, const X&, const Vecs&... vecs) -> DrawSpecs&;
+
+    //======================================================================
+    // METHODS FOR DRAWING PLOT ELEMENTS USING DATA FROM LOCAL FILES
+    //======================================================================
+
+    /// Draw plot object with given style and given vectors (e.g., `plot.draw("lines", x, y)`).
+    auto drawWithCols(const std::string& fname, const std::string& with, const std::vector<ColumnIndex>& cols) -> DrawSpecs&;
+
+    //======================================================================
+    // MISCELLANEOUS METHODS
+    //======================================================================
+
+    /// Convert this plot object into a gnuplot formatted string.
+    auto repr() const -> std::string override;
+
+  private:
+    std::string m_zrange; ///< The z-range of the plot as a gnuplot formatted string (e.g., "set yrange [0:1]")
+    AxisLabelSpecs m_zlabel; ///< The label of the z-axis
+};
+
+inline Plot3DImpl::Plot3DImpl()
+    : m_zlabel("z")
+{
+}
+
+inline auto Plot3DImpl::zlabel(const std::string& label) -> AxisLabelSpecs&
+{
+    m_zlabel.text(label);
+    return m_zlabel;
+}
+
+inline auto Plot3DImpl::zrange(StringOrDouble min, StringOrDouble max) -> void
+{
+    m_zrange = "[" + min.value + ":" + max.value + "]";
+}
+
+//======================================================================
+// METHODS FOR DRAWING PLOT ELEMENTS
+//======================================================================
+
+template <typename X, typename... Vecs>
+inline auto Plot3DImpl::drawWithVecs(const std::string& with, const X& x, const Vecs&... vecs) -> DrawSpecs&
+{
+    // Write the given vectors x and y as a new data set to the stream
+    std::ostringstream datastream;
+    gnuplot::writedataset(datastream, m_numdatasets, x, vecs...);
+
+    // Set the using string to "" if X is not vector of strings.
+    // Otherwise, x contain xtics strings. Set the `using` string
+    // so that these are properly used as xtics.
+    std::string use;
+    if constexpr (internal::isStringVector<X>)
+    {
+        const auto nvecs = sizeof...(Vecs);
+        use = "0:"; // here, column 0 means the pseudo column with numbers 0, 1, 2, 3...
+        for (auto i = 2; i <= nvecs + 1; ++i)
+            use += std::to_string(i) + ":"; // this constructs 0:2:3:4:
+        use += "xtic(1)"; // this terminates the string with 0:2:3:4:xtic(1), and thus column 1 is used for the xtics
+    }
+
+    // Append new data set to existing data
+    m_data += datastream.str();
+
+    // Draw the data saved using a data set with index `m_numdatasets`. Increase number of data sets and set the line style specification (desired behavior is 1, 2, 3 (incrementing as new lines are plotted)).
+    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(m_drawspecs.size());
+    ;
+}
+
+//======================================================================
+// METHODS FOR DRAWING PLOT ELEMENTS USING DATA FROM LOCAL FILES
+//======================================================================
+
+inline auto Plot3DImpl::drawWithCols(const std::string& fname, const std::string& with, const std::vector<ColumnIndex>& cols) -> DrawSpecs&
+{
+    std::string use;
+    for (auto col : cols)
+        use += col.value + ":"; // e.g., "1:4:5:7:" (where 1 is x, 4 is y, 5 is ylow and 7 is yhigh for a yerrorlines plot)
+    use = internal::trimright(use, ':'); // e.g., "1:4:5:7:" => "1:4:5:7"
+    std::string what = "'" + fname + "'"; // e.g., "'myfile.dat'"
+    return draw(what, use, with).lineStyle(m_drawspecs.size());
+    ; // e.g., draw(what="'myfile.dat'", use="1:2", with="lines");
+}
+
+//======================================================================
+// MISCElLANEOUS METHODS
+//======================================================================
+
+inline auto Plot3DImpl::repr() const -> std::string
+{
+    std::stringstream script;
+
+    // Add plot setup commands
+    script << "#==============================================================================" << std::endl;
+    script << "# SETUP COMMANDS" << std::endl;
+    script << "#==============================================================================" << std::endl;
+    script << gnuplot::commandValueStr("set xrange", m_xrange);
+    script << gnuplot::commandValueStr("set yrange", m_yrange);
+    script << gnuplot::commandValueStr("set zrange", m_zrange);
+    script << m_xlabel << std::endl;
+    script << m_ylabel << std::endl;
+    script << m_zlabel << std::endl;
+    script << m_rlabel << std::endl;
+    script << m_border << std::endl;
+    script << m_grid << std::endl;
+    script << m_style_fill << std::endl;
+    script << m_style_histogram << std::endl;
+    script << m_tics << std::endl;
+    script << m_xtics_major_bottom << std::endl;
+    script << m_xtics_major_top << std::endl;
+    script << m_xtics_minor_bottom << std::endl;
+    script << m_xtics_minor_top << std::endl;
+    script << m_ytics_major_left << std::endl;
+    script << m_ytics_major_right << std::endl;
+    script << m_ytics_minor_left << std::endl;
+    script << m_ytics_minor_right << std::endl;
+    script << m_ztics_major << std::endl;
+    script << m_ztics_minor << std::endl;
+    script << m_rtics_major << std::endl;
+    script << m_rtics_minor << std::endl;
+    script << m_legend << std::endl;
+    script << gnuplot::commandValueStr("set boxwidth", m_boxwidth);
+    script << gnuplot::commandValueStr("set samples", m_samples);
+
+    // Add custom gnuplot commands
+    if (!m_customcmds.empty())
+    {
+        script << "#==============================================================================" << std::endl;
+        script << "# CUSTOM EXPLICIT GNUPLOT COMMANDS" << std::endl;
+        script << "#==============================================================================" << std::endl;
+        for (const auto& c : m_customcmds)
+        {
+            script << c << std::endl;
+        }
+    }
+
+    // Add the actual plot commands for all drawXYZ() calls
+    script << "#==============================================================================" << std::endl;
+    script << "# PLOT COMMANDS" << std::endl;
+    script << "#==============================================================================" << std::endl;
+    script << "splot \\\n"; // use `\` to have a plot command in each individual line!
+
+    // Write plot commands and style per plot
+    const auto n = m_drawspecs.size();
+    for (std::size_t i = 0; i < n; ++i)
+        script << "    " << m_drawspecs[i] << (i < n - 1 ? ", \\\n" : ""); // consider indentation with 4 spaces!
+
+    // Add an empty line at the end
+    script << std::endl;
+    return script.str();
+}
+
+} // namespace internal
+
+} // namespace sciplot

--- a/sciplot/PlotBase.hpp
+++ b/sciplot/PlotBase.hpp
@@ -3,7 +3,7 @@
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
 //
-// Copyright (c) 2018-2021 Allan Leal
+// Copyright (c) 2018-2021 Allan Leal, Bim Overbohm
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,7 @@
 #include <sciplot/Constants.hpp>
 #include <sciplot/Default.hpp>
 #include <sciplot/Enums.hpp>
+#include <sciplot/IPlot.hpp>
 #include <sciplot/Palettes.hpp>
 #include <sciplot/StringOrDouble.hpp>
 #include <sciplot/Utils.hpp>
@@ -52,106 +53,106 @@
 namespace sciplot
 {
 
+namespace internal
+{
+
 /// The class used to create a plot containing graphical elements.
-class PlotBase
+class PlotBase : public IPlot
 {
   public:
     /// Construct a default Plot object
     PlotBase();
 
-    /// Virtual destructor to avoid memory leaks
-    virtual ~PlotBase() = default;
-
     /// Set the palette of colors for the plot.
     /// @param name Any palette name displayed in https://github.com/Gnuplotting/gnuplot-palettes, such as "viridis", "parula", "jet".
-    auto palette(const std::string& name) -> void;
+    auto palette(const std::string& name) -> void override;
 
     /// Set the size of the plot (in unit of points, with 1 inch = 72 points).
-    auto size(std::size_t width, std::size_t height) -> void;
+    auto size(std::size_t width, std::size_t height) -> void override;
 
     /// Set the font name for the plot (e.g., Helvetica, Georgia, Times).
-    auto fontName(const std::string& name) -> void;
+    auto fontName(const std::string& name) -> void override;
 
     /// Set the font size for the plot (e.g., 10, 12, 16).
-    auto fontSize(std::size_t size) -> void;
+    auto fontSize(std::size_t size) -> void override;
 
     /// Set the border of the plot and return a reference to the corresponding specs object.
-    auto border() -> BorderSpecs& { return m_border; }
+    auto border() -> BorderSpecs& override { return m_border; }
 
     /// Set the grid of the plot and return a reference to the corresponding specs object.
-    auto grid() -> GridSpecs& { return m_grid; }
+    auto grid() -> GridSpecs& override { return m_grid; }
 
     /// Set the label of the x-axis and return a reference to the corresponding specs object.
-    auto xlabel(const std::string& label) -> AxisLabelSpecs&;
+    auto xlabel(const std::string& label) -> AxisLabelSpecs& override;
 
     /// Set the label of the y-axis and return a reference to the corresponding specs object.
-    auto ylabel(const std::string& label) -> AxisLabelSpecs&;
+    auto ylabel(const std::string& label) -> AxisLabelSpecs& override;
 
     /// Set the x-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
-    auto xrange(const StringOrDouble& min, const StringOrDouble& max) -> void;
+    auto xrange(const StringOrDouble& min, const StringOrDouble& max) -> void override;
 
     /// Set the y-range of the plot (also possible with empty values or autoscale options (e.g. "", "*")).
-    auto yrange(const StringOrDouble& min, const StringOrDouble& max) -> void;
+    auto yrange(const StringOrDouble& min, const StringOrDouble& max) -> void override;
 
     /// Set the default width of boxes in plots containing boxes (in absolute mode).
     /// In absolute mode, a unit width is equivalent to one unit of length along the *x* axis.
-    auto boxWidthAbsolute(double val) -> void;
+    auto boxWidthAbsolute(double val) -> void override;
 
     /// Set the default width of boxes in plots containing boxes (in relative mode).
     /// In relative mode, a unit width is equivalent to setting the boxes side by side.
-    auto boxWidthRelative(double val) -> void;
+    auto boxWidthRelative(double val) -> void override;
 
     //======================================================================
     // METHODS FOR CUSTOMIZATION OF TICS
     //======================================================================
 
     /// Set the tics of the plot and return a reference to the corresponding specs object.
-    auto tics() -> TicsSpecs& { return m_tics; }
+    auto tics() -> TicsSpecs& override { return m_tics; }
 
     /// Return the specifications of the grid lines along major xtics on the bottom axis.
-    auto xtics() -> TicsSpecsMajor& { return xticsMajorBottom(); }
+    auto xtics() -> TicsSpecsMajor& override { return xticsMajorBottom(); }
 
     /// Return the specifications of the grid lines along major ytics on the left axis.
-    auto ytics() -> TicsSpecsMajor& { return yticsMajorLeft(); }
+    auto ytics() -> TicsSpecsMajor& override { return yticsMajorLeft(); }
 
     /// Return the specifications of the grid lines along major ztics.
-    auto ztics() -> TicsSpecsMajor& { return zticsMajor(); }
+    auto ztics() -> TicsSpecsMajor& override { return zticsMajor(); }
 
     /// Return the specifications of the grid lines along major rtics.
-    auto rtics() -> TicsSpecsMajor& { return rticsMajor(); }
+    auto rtics() -> TicsSpecsMajor& override { return rticsMajor(); }
 
     /// Return the specifications of the grid lines along major xtics on the bottom axis.
-    auto xticsMajorBottom() -> TicsSpecsMajor& { return m_xtics_major_bottom; }
+    auto xticsMajorBottom() -> TicsSpecsMajor& override { return m_xtics_major_bottom; }
 
     /// Return the specifications of the grid lines along major xtics on the top axis.
-    auto xticsMajorTop() -> TicsSpecsMajor& { return m_xtics_major_top; }
+    auto xticsMajorTop() -> TicsSpecsMajor& override { return m_xtics_major_top; }
 
     /// Return the specifications of the grid lines along minor xtics on the bottom axis.
-    auto xticsMinorBottom() -> TicsSpecsMinor& { return m_xtics_minor_bottom; }
+    auto xticsMinorBottom() -> TicsSpecsMinor& override { return m_xtics_minor_bottom; }
 
     /// Return the specifications of the grid lines along minor xtics on the top axis.
-    auto xticsMinorTop() -> TicsSpecsMinor& { return m_xtics_minor_top; }
+    auto xticsMinorTop() -> TicsSpecsMinor& override { return m_xtics_minor_top; }
 
     /// Return the specifications of the grid lines along major ytics on the left axis.
-    auto yticsMajorLeft() -> TicsSpecsMajor& { return m_ytics_major_left; }
+    auto yticsMajorLeft() -> TicsSpecsMajor& override { return m_ytics_major_left; }
 
     /// Return the specifications of the grid lines along major ytics on the right axis.
-    auto yticsMajorRight() -> TicsSpecsMajor& { return m_ytics_major_right; }
+    auto yticsMajorRight() -> TicsSpecsMajor& override { return m_ytics_major_right; }
 
     /// Return the specifications of the grid lines along minor ytics on the left axis.
-    auto yticsMinorLeft() -> TicsSpecsMinor& { return m_ytics_minor_left; }
+    auto yticsMinorLeft() -> TicsSpecsMinor& override { return m_ytics_minor_left; }
 
     /// Return the specifications of the grid lines along minor ytics on the right axis.
-    auto yticsMinorRight() -> TicsSpecsMinor& { return m_ytics_minor_right; }
+    auto yticsMinorRight() -> TicsSpecsMinor& override { return m_ytics_minor_right; }
 
     /// Return the specifications of the grid lines along major ztics.
-    auto zticsMajor() -> TicsSpecsMajor& { return m_ztics_major; }
+    auto zticsMajor() -> TicsSpecsMajor& override { return m_ztics_major; }
 
     /// Return the specifications of the grid lines along minor ztics.
-    auto zticsMinor() -> TicsSpecsMinor& { return m_ztics_minor; }
+    auto zticsMinor() -> TicsSpecsMinor& override { return m_ztics_minor; }
 
     /// Return the specifications of the grid lines along minor rtics.
-    auto rticsMajor() -> TicsSpecsMajor& { return m_rtics_major; }
+    auto rticsMajor() -> TicsSpecsMajor& override { return m_rtics_major; }
 
     /// Return the specifications of the grid lines along minor rtics.
     auto rticsMinor() -> TicsSpecsMinor& { return m_rtics_minor; }
@@ -161,58 +162,55 @@ class PlotBase
     //======================================================================
 
     /// Return an object that permits fill style to be customized.
-    auto styleFill() -> FillStyleSpecs& { return m_style_fill; }
+    auto styleFill() -> FillStyleSpecs& override { return m_style_fill; }
 
     /// Return an object that permits histogram style to be customized.
-    auto styleHistogram() -> HistogramStyleSpecs& { return m_style_histogram; }
+    auto styleHistogram() -> HistogramStyleSpecs& override { return m_style_histogram; }
 
     //======================================================================
     // METHODS FOR DRAWING PLOT ELEMENTS
     //======================================================================
 
     /// Draw plot object with given `what`, `using` and `with` expressions (e.g., `plot.draw("sin(x)*cos(x)", "", "linespoints")`,  (e.g., `plot.draw("file.dat", "1:2", "points")`)).
-    auto draw(const std::string& what, const std::string& use, const std::string& with) -> DrawSpecs&;
+    auto draw(const std::string& what, const std::string& use, const std::string& with) -> DrawSpecs& override;
 
     //======================================================================
     // MISCElLANEOUS METHODS
     //======================================================================
 
     /// Set the legend of the plot and return a reference to the corresponding specs object.
-    auto legend() -> LegendSpecs&;
+    auto legend() -> LegendSpecs& override;
 
     /// Set the number of sample points for analytical plots.
-    auto samples(std::size_t value) -> void;
+    auto samples(std::size_t value) -> void override;
 
     /// Use this method to provide gnuplot commands to be executed before the plotting calls.
-    auto gnuplot(const std::string& command) -> void;
+    auto gnuplot(const std::string& command) -> void override;
 
     /// Show the plot in a pop-up window.
     /// @note This method removes temporary files after saving if `PlotBase::autoclean(true)` (default).
-    auto show() const -> void;
+    auto show() const -> void override;
 
     /// Save the plot in a file, with its extension defining the file format.
     /// The extension of the file name determines the file format.
     /// The supported formats are: `pdf`, `eps`, `svg`, `png`, and `jpeg`.
     /// Thus, to save a plot in `pdf` format, choose a file as in `plot.pdf`.
     /// @note This method removes temporary files after saving if `PlotBase::autoclean(true)` (default).
-    auto save(const std::string& filename) const -> void;
+    auto save(const std::string& filename) const -> void override;
 
     /// Write the current plot data to the data file.
-    auto savePlotData() const -> void;
+    auto savePlotData() const -> void override;
 
     /// Toggle automatic cleaning of temporary files (enabled by default). Pass false if you want to keep your script / data files.
     /// Call cleanup() to remove those files manually.
-    auto autoclean(bool enable = true) -> void;
+    auto autoclean(bool enable = true) -> void override;
 
     /// Delete all files used to store plot data or scripts.
-    auto cleanup() const -> void;
+    auto cleanup() const -> void override;
 
     /// Clear all draw and gnuplot commands.
     /// @note This method leaves all other plot properties untouched.
-    auto clear() -> void;
-
-    /// Convert this plot object into a gnuplot formatted string.
-    virtual auto repr() const -> std::string = 0;
+    auto clear() -> void override;
 
   protected:
     static std::size_t m_counter; ///< Counter of how many plot / singleplot objects have been instanciated in the application
@@ -482,5 +480,7 @@ inline auto PlotBase::clear() -> void
     m_drawspecs.clear();
     m_customcmds.clear();
 }
+
+} // namespace internal
 
 } // namespace sciplot

--- a/sciplot/PlotImpl.hpp
+++ b/sciplot/PlotImpl.hpp
@@ -1,0 +1,225 @@
+// sciplot - a modern C++ scientific plotting library powered by gnuplot
+// https://github.com/sciplot/sciplot
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+//
+// Copyright (c) 2018-2021 Allan Leal, Bim Overbohm
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+// C++ includes
+#include <sstream>
+#include <vector>
+
+// sciplot includes
+#include <sciplot/Constants.hpp>
+#include <sciplot/Default.hpp>
+#include <sciplot/Enums.hpp>
+#include <sciplot/Palettes.hpp>
+#include <sciplot/PlotBase.hpp>
+#include <sciplot/StringOrDouble.hpp>
+#include <sciplot/Utils.hpp>
+#include <sciplot/specs/AxisLabelSpecs.hpp>
+#include <sciplot/specs/BorderSpecs.hpp>
+#include <sciplot/specs/DrawSpecs.hpp>
+#include <sciplot/specs/FillStyleSpecs.hpp>
+#include <sciplot/specs/FontSpecsOf.hpp>
+#include <sciplot/specs/GridSpecs.hpp>
+#include <sciplot/specs/HistogramStyleSpecs.hpp>
+#include <sciplot/specs/LegendSpecs.hpp>
+#include <sciplot/specs/LineSpecsOf.hpp>
+#include <sciplot/specs/TicsSpecs.hpp>
+#include <sciplot/specs/TicsSpecsMajor.hpp>
+#include <sciplot/specs/TicsSpecsMinor.hpp>
+
+namespace sciplot
+{
+
+namespace internal
+{
+
+/// The class used to create a plot containing graphical elements.
+class PlotImpl : public PlotBase
+{
+  public:
+    //======================================================================
+    // METHODS FOR DRAWING PLOT ELEMENTS
+    //======================================================================
+
+    /// Draw plot object with given style and given vectors (e.g., `plot.draw("lines", x, y)`).
+    template <typename X, typename... Vecs>
+    auto drawWithVecs(const std::string& with, const X&, const Vecs&... vecs) -> DrawSpecs&;
+
+    /// Draw plot object with given style and given vectors (e.g., `plot.draw("lines", x, y)`) that may contain NaN values.
+    template <typename X, typename... Vecs>
+    auto drawWithVecsContainingNaN(std::string with, const X&, const Vecs&... vecs) -> DrawSpecs&;
+
+    //======================================================================
+    // METHODS FOR DRAWING PLOT ELEMENTS USING DATA FROM LOCAL FILES
+    //======================================================================
+
+    /// Draw plot object with given style and given vectors (e.g., `plot.draw("lines", x, y)`).
+    auto drawWithCols(const std::string& fname, const std::string& with, const std::vector<ColumnIndex>& cols) -> DrawSpecs&;
+
+    //======================================================================
+    // MISCELLANEOUS METHODS
+    //======================================================================
+
+    /// Convert this plot object into a gnuplot formatted string.
+    auto repr() const -> std::string override;
+};
+
+//======================================================================
+// METHODS FOR DRAWING PLOT ELEMENTS
+//======================================================================
+
+template <typename X, typename... Vecs>
+inline auto PlotImpl::drawWithVecs(const std::string& with, const X& x, const Vecs&... vecs) -> DrawSpecs&
+{
+    // Write the given vectors x and y as a new data set to the stream
+    std::ostringstream datastream;
+    gnuplot::writedataset(datastream, m_numdatasets, x, vecs...);
+
+    // Set the using string to "" if X is not vector of strings.
+    // Otherwise, x contain xtics strings. Set the `using` string
+    // so that these are properly used as xtics.
+    std::string use;
+    if constexpr (internal::isStringVector<X>)
+    {
+        const auto nvecs = sizeof...(Vecs);
+        use = "0:"; // here, column 0 means the pseudo column with numbers 0, 1, 2, 3...
+        for (auto i = 2; i <= nvecs + 1; ++i)
+            use += std::to_string(i) + ":"; // this constructs 0:2:3:4:
+        use += "xtic(1)"; // this terminates the string with 0:2:3:4:xtic(1), and thus column 1 is used for the xtics
+    }
+
+    // Append new data set to existing data
+    m_data += datastream.str();
+
+    // Draw the data saved using a data set with index `m_numdatasets`. Increase number of data sets and set the line style specification (desired behavior is 1, 2, 3 (incrementing as new lines are plotted)).
+    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(m_drawspecs.size());
+}
+
+template <typename X, typename... Vecs>
+inline auto PlotImpl::drawWithVecsContainingNaN(std::string with, const X& x, const Vecs&... vecs) -> DrawSpecs&
+{
+    // Write the given vectors x and y as a new data set to the stream
+    std::ostringstream datastream;
+    gnuplot::writedataset(datastream, m_numdatasets, x, vecs...);
+
+    std::string use;
+    const auto nvecs = sizeof...(Vecs);
+    use = "0:"; // here, column 0 means the pseudo column with numbers 0, 1, 2, 3...
+    for (auto i = 2; i <= nvecs + 1; ++i)
+        use += "($" + std::to_string(i) + "):"; // this constructs 0:$(2):$(3):$(4):
+    use += "xtic(1)"; // this terminates the string with 0:$(2):$(3):$(4):xtic(1), and thus column 1 is used for the xtics
+
+    // Append new data set to existing data
+    m_data += datastream.str();
+
+    // Draw the data saved using a data set with index `m_numdatasets`. Increase number of data sets and set the line style specification (desired behavior is 1, 2, 3 (incrementing as new lines are plotted)).
+    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(m_drawspecs.size());
+}
+
+//======================================================================
+// METHODS FOR DRAWING PLOT ELEMENTS USING DATA FROM LOCAL FILES
+//======================================================================
+
+inline auto PlotImpl::drawWithCols(const std::string& fname, const std::string& with, const std::vector<ColumnIndex>& cols) -> DrawSpecs&
+{
+    std::string use;
+    for (const auto& col : cols)
+        use += col.value + ":"; // e.g., "1:4:5:7:" (where 1 is x, 4 is y, 5 is ylow and 7 is yhigh for a yerrorlines plot)
+    use = internal::trimright(use, ':'); // e.g., "1:4:5:7:" => "1:4:5:7"
+    std::string what = "'" + fname + "'"; // e.g., "'myfile.dat'"
+    return draw(what, use, with).lineStyle(m_drawspecs.size()); // e.g., draw(what="'myfile.dat'", use="1:2", with="lines");
+}
+
+//======================================================================
+// MISCELLANEOUS METHODS
+//======================================================================
+
+inline auto PlotImpl::repr() const -> std::string
+{
+    std::stringstream script;
+
+    // Add plot setup commands
+    script << "#==============================================================================" << std::endl;
+    script << "# SETUP COMMANDS" << std::endl;
+    script << "#==============================================================================" << std::endl;
+    script << gnuplot::commandValueStr("set xrange", m_xrange);
+    script << gnuplot::commandValueStr("set yrange", m_yrange);
+    script << m_xlabel << std::endl;
+    script << m_ylabel << std::endl;
+    script << m_rlabel << std::endl;
+    script << m_border << std::endl;
+    script << m_grid << std::endl;
+    script << m_style_fill << std::endl;
+    script << m_style_histogram << std::endl;
+    script << m_tics << std::endl;
+    script << m_xtics_major_bottom << std::endl;
+    script << m_xtics_major_top << std::endl;
+    script << m_xtics_minor_bottom << std::endl;
+    script << m_xtics_minor_top << std::endl;
+    script << m_ytics_major_left << std::endl;
+    script << m_ytics_major_right << std::endl;
+    script << m_ytics_minor_left << std::endl;
+    script << m_ytics_minor_right << std::endl;
+    script << m_ztics_major << std::endl;
+    script << m_ztics_minor << std::endl;
+    script << m_rtics_major << std::endl;
+    script << m_rtics_minor << std::endl;
+    script << m_legend << std::endl;
+    script << gnuplot::commandValueStr("set boxwidth", m_boxwidth);
+    script << gnuplot::commandValueStr("set samples", m_samples);
+    script << gnuplot::commandValueStr("set datafile missing", MISSING_INDICATOR);
+
+    // Add custom gnuplot commands
+    if (!m_customcmds.empty())
+    {
+        script << "#==============================================================================" << std::endl;
+        script << "# CUSTOM EXPLICIT GNUPLOT COMMANDS" << std::endl;
+        script << "#==============================================================================" << std::endl;
+        for (const auto& c : m_customcmds)
+        {
+            script << c << std::endl;
+        }
+    }
+
+    // Add the actual plot commands for all drawXYZ() calls
+    script << "#==============================================================================" << std::endl;
+    script << "# PLOT COMMANDS" << std::endl;
+    script << "#==============================================================================" << std::endl;
+    script << "plot \\\n"; // use `\` to have a plot command in each individual line!
+
+    // Write plot commands and style per plot
+    const auto n = m_drawspecs.size();
+    for (std::size_t i = 0; i < n; ++i)
+        script << "    " << m_drawspecs[i] << (i < n - 1 ? ", \\\n" : ""); // consider indentation with 4 spaces!
+
+    // Add an empty line at the end
+    script << std::endl;
+    return script.str();
+}
+
+} // namespace internal
+
+} // namespace sciplot


### PR DESCRIPTION
This a semi-successful try of mine to get "shared plot object", transparent to the user to address the somewhat valid bug/request #57. Though it does work and has its advantages I'm not sure it is the right thing to do. See the [example](examples/example-plot-reference.cpp). All copied plots now reference each other. Not sure if this is something we want...
Comments, ideas and corrections are welcome.