### PR TITLE
Compile warning fixes

### DIFF
--- a/sciplot/Default.hpp
+++ b/sciplot/Default.hpp
@@ -25,6 +25,9 @@
 
 #pragma once
 
+// C++ includes
+#include <cmath>
+
 // sciplot includes
 #include <sciplot/Constants.hpp>
 #include <sciplot/Enums.hpp>
@@ -34,7 +37,7 @@ namespace internal
 {
 
 const auto DEFAULT_FIGURE_HEIGHT = 200; // this is equivalent to 6 inches if 1 in = 72 points
-const auto DEFAULT_FIGURE_WIDTH = DEFAULT_FIGURE_HEIGHT * GOLDEN_RATIO;
+const auto DEFAULT_FIGURE_WIDTH = static_cast<size_t> (std::round (DEFAULT_FIGURE_HEIGHT * GOLDEN_RATIO));
 const auto DEFAULT_FIGURE_BOXWIDTH_RELATIVE = 0.9;
 
 const auto DEFAULT_PALETTE = "dark2";

--- a/sciplot/Plot.hpp
+++ b/sciplot/Plot.hpp
@@ -324,7 +324,7 @@ inline auto Plot::drawWithVecs(const std::string& with, const X& x, const Vecs&.
     m_data += datastream.str();
 
     // Draw the data saved using a data set with index `m_numdatasets`. Increase number of data sets and set the line style specification (desired behavior is 1, 2, 3 (incrementing as new lines are plotted)).
-    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(m_drawspecs.size());
+    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(static_cast<int> (m_drawspecs.size()));
 }
 
 template <typename X, typename... Vecs>
@@ -345,7 +345,7 @@ inline auto Plot::drawWithVecsContainingNaN(std::string with, const X& x, const 
     m_data += datastream.str();
 
     // Draw the data saved using a data set with index `m_numdatasets`. Increase number of data sets and set the line style specification (desired behavior is 1, 2, 3 (incrementing as new lines are plotted)).
-    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(m_drawspecs.size());
+    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(static_cast<int> (m_drawspecs.size()));
 }
 
 template <typename X, typename Y>
@@ -545,7 +545,7 @@ inline auto Plot::drawWithCols(const std::string& fname, const std::string& with
         use += col.value + ":"; // e.g., "1:4:5:7:" (where 1 is x, 4 is y, 5 is ylow and 7 is yhigh for a yerrorlines plot)
     use = internal::trimright(use, ':'); // e.g., "1:4:5:7:" => "1:4:5:7"
     std::string what = "'" + fname + "'"; // e.g., "'myfile.dat'"
-    return draw(what, use, with).lineStyle(m_drawspecs.size()); // e.g., draw(what="'myfile.dat'", use="1:2", with="lines");
+    return draw(what, use, with).lineStyle(static_cast<int> (m_drawspecs.size())); // e.g., draw(what="'myfile.dat'", use="1:2", with="lines");
 }
 
 inline auto Plot::drawCurve(const std::string& fname, ColumnIndex xcol, ColumnIndex ycol) -> DrawSpecs&

--- a/sciplot/Plot3D.hpp
+++ b/sciplot/Plot3D.hpp
@@ -179,7 +179,7 @@ inline auto Plot3D::drawWithVecs(const std::string& with, const X& x, const Vecs
     m_data += datastream.str();
 
     // Draw the data saved using a data set with index `m_numdatasets`. Increase number of data sets and set the line style specification (desired behavior is 1, 2, 3 (incrementing as new lines are plotted)).
-    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(m_drawspecs.size());
+    return draw("'" + m_datafilename + "' index " + internal::str(m_numdatasets++), use, with).lineStyle(static_cast<int> (m_drawspecs.size()));
     ;
 }
 
@@ -231,7 +231,7 @@ inline auto Plot3D::drawWithCols(const std::string& fname, const std::string& wi
         use += col.value + ":"; // e.g., "1:4:5:7:" (where 1 is x, 4 is y, 5 is ylow and 7 is yhigh for a yerrorlines plot)
     use = internal::trimright(use, ':'); // e.g., "1:4:5:7:" => "1:4:5:7"
     std::string what = "'" + fname + "'"; // e.g., "'myfile.dat'"
-    return draw(what, use, with).lineStyle(m_drawspecs.size());
+    return draw(what, use, with).lineStyle(static_cast<int> (m_drawspecs.size()));
     ; // e.g., draw(what="'myfile.dat'", use="1:2", with="lines");
 }
 

--- a/sciplot/specs/HistogramStyleSpecs.hpp
+++ b/sciplot/specs/HistogramStyleSpecs.hpp
@@ -127,8 +127,8 @@ inline auto HistogramStyleSpecs::errorBarsWithLineWidth(double value) -> Histogr
 
 inline auto HistogramStyleSpecs::repr() const -> std::string
 {
-    const auto supports_gap = (m_type == "clustered" || m_type == "errorbars");
-    const auto supports_linewidth = (m_type == "errorbars");
+    [[maybe_unused]] const auto supports_gap = (m_type == "clustered" || m_type == "errorbars");
+    [[maybe_unused]] const auto supports_linewidth = (m_type == "errorbars");
 
     std::stringstream ss;
     ss << "set style histogram" << " ";


### PR DESCRIPTION
This pull request fixes various compile warnings that I encountered when building sciplot with AppleClang 12.