### PR TITLE
Support sciplot as a cmake subproject

### DIFF
--- a/cmake_install_generation.cmake
+++ b/cmake_install_generation.cmake
@@ -41,8 +41,8 @@ install(EXPORT sciplot-export
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
-        ${CMAKE_SOURCE_DIR}/cmake/PackageConfigTemplates/sciplotConfig.cmake.in
-        ${CMAKE_BINARY_DIR}/sciplotConfig.cmake
+        ${PROJECT_SOURCE_DIR}/cmake/PackageConfigTemplates/sciplotConfig.cmake.in
+        ${PROJECT_BINARY_DIR}/sciplotConfig.cmake
         INSTALL_DESTINATION
         ${CMAKE_INSTALL_DATAROOTDIR}/${CMAKE_PROJECT_NAME}/
 )
@@ -57,8 +57,8 @@ write_basic_package_version_file(
 # install generated files
 
 install(FILES
-        ${CMAKE_BINARY_DIR}/sciplotConfig.cmake
-        ${CMAKE_BINARY_DIR}/sciplotConfigVersion.cmake
+        ${PROJECT_BINARY_DIR}/sciplotConfig.cmake
+        ${PROJECT_BINARY_DIR}/sciplotConfigVersion.cmake
         DESTINATION
         ${CMAKE_INSTALL_DATAROOTDIR}/${CMAKE_PROJECT_NAME}/
         )


### PR DESCRIPTION
CMAKE_{SOURCE,BINARY}_DIR point at the top level of the source/build
tree. This works well when sciplot is the top level project. However if
sciplot is ingested as a subproject via add_subdirectory, they point at
the parents source/build dir instead.

Using PROJECT_{SOURCE,BINARY}_DIR instead.