### PR TITLE
Fix compile warnings (-Werror)

### DIFF
--- a/sciplot/Plot.hpp
+++ b/sciplot/Plot.hpp
@@ -247,7 +247,7 @@ class Plot
 inline std::size_t Plot::m_counter = 0;
 
 inline Plot::Plot()
-    : m_id(m_counter++), m_datafilename("plot" + internal::str(m_id) + ".dat"), m_xlabel("x"), m_ylabel("y"), m_rlabel("r"), m_xtics_major_bottom("x"), m_xtics_major_top("x2"), m_xtics_minor_bottom("x"), m_xtics_minor_top("x2"), m_ytics_major_left("y"), m_ytics_major_right("y2"), m_ytics_minor_left("y"), m_ytics_minor_right("y2"), m_ztics_major("z"), m_ztics_minor("z"), m_rtics_major("r"), m_rtics_minor("r")
+    : m_id(m_counter++), m_datafilename("plot" + internal::str(m_id) + ".dat"), m_xtics_major_bottom("x"), m_xtics_major_top("x2"), m_xtics_minor_bottom("x"), m_xtics_minor_top("x2"), m_ytics_major_left("y"), m_ytics_major_right("y2"), m_ytics_minor_left("y"), m_ytics_minor_right("y2"), m_ztics_major("z"), m_ztics_minor("z"), m_rtics_major("r"), m_rtics_minor("r"), m_xlabel("x"), m_ylabel("y"), m_rlabel("r")
 {
     // Show only major and minor xtics and ytics
     xticsMajorBottom().show();

--- a/sciplot/specs/TicsSpecsMajor.hpp
+++ b/sciplot/specs/TicsSpecsMajor.hpp
@@ -146,7 +146,7 @@ inline auto TicsSpecsMajor::at(const std::vector<double>& values) -> TicsSpecsMa
 {
     std::stringstream ss;
     ss << "(";
-    for (auto i = 0; i < values.size(); ++i)
+    for (decltype(values.size()) i = 0; i < values.size(); ++i)
         ss << (i == 0 ? "" : ", ") << values[i];
     ss << ")";
     m_at = ss.str();
@@ -157,7 +157,7 @@ inline auto TicsSpecsMajor::at(const std::vector<double>& values, const std::vec
 {
     std::stringstream ss;
     ss << "(";
-    for (auto i = 0; i < values.size(); ++i)
+    for (decltype(values.size()) i = 0; i < values.size(); ++i)
         ss << (i == 0 ? "" : ", ") << "'" << labels[i] << "' " << values[i];
     ss << ")";
     m_at = ss.str();
@@ -168,7 +168,7 @@ inline auto TicsSpecsMajor::add(const std::vector<double>& values) -> TicsSpecsM
 {
     std::stringstream ss;
     ss << "add (";
-    for (auto i = 0; i < values.size(); ++i)
+    for (decltype(values.size()) i = 0; i < values.size(); ++i)
         ss << (i == 0 ? "" : ", ") << values[i];
     ss << ")";
     m_add = ss.str();
@@ -179,7 +179,7 @@ inline auto TicsSpecsMajor::add(const std::vector<double>& values, const std::ve
 {
     std::stringstream ss;
     ss << "add (";
-    for (auto i = 0; i < values.size(); ++i)
+    for (decltype(values.size()) i = 0; i < values.size(); ++i)
         ss << (i == 0 ? "" : ", ") << "'" << labels[i] << "' " << values[i];
     ss << ")";
     m_add = ss.str();


### PR DESCRIPTION
Resolve the following when compiled with `-Wall -Wextra -Werror -pedantic`:
```
-Werror=sign-compare
-Werror=reorder
```