### PR TITLE
Fixed template type for y uncertainty on boxes

### DIFF
--- a/sciplot/Plot2D.hpp
+++ b/sciplot/Plot2D.hpp
@@ -129,7 +129,7 @@ class Plot2D : public Plot
 
     /// Draw boxes with error bars along *y* with given @p x, @p y, @p ydelta vectors.
     template <typename X, typename Y, typename YD>
-    auto drawBoxesWithErrorBarsY(const X& x, const Y& y, const Y& ydelta) -> DrawSpecs&;
+    auto drawBoxesWithErrorBarsY(const X& x, const Y& y, const YD& ydelta) -> DrawSpecs&;
 
     /// Draw boxes with error bars along *y* with given @p x, @p y, @p ylow, and @p yhigh vectors.
     template <typename X, typename Y, typename YL, typename YH>


### PR DESCRIPTION
This PR fixes a compilation error when specifying y uncertainty on box plots, as the `YD` template type argument is currently declared but not used.
A potential improvement would be to define a default type `YD=Y` (and same for other equivalent delta-templated methods).