### PR TITLE
Throw an exception if gnuplot fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # Prerequisites
 *.d
 
-# Visual Studio Code directory
+# Visual Studio & VS Code directories
 .vscode/
+.vs/
 
 # Build directories
 build/

--- a/sciplot/Utils.hpp
+++ b/sciplot/Utils.hpp
@@ -338,11 +338,15 @@ inline auto multiplotcmd(std::ostream& out, std::size_t rows, std::size_t column
 /// Auxiliary function to run gnuplot to show or save a script file
 // persistent == true: for show commands. show the file using GNUplot until the window is closed
 // persistent == false: for save commands. close gnuplot immediately
-inline auto runscript(std::string scriptfilename, bool persistent) -> bool
+inline auto runscript(std::string scriptfilename, bool persistent)
 {
     std::string command = persistent ? "gnuplot -persistent " : "gnuplot ";
     command += "\"" + scriptfilename + "\"";
-    return std::system(command.c_str()) == 0;
+    if (auto retval{std::system(command.c_str())};
+        !retval)
+    {
+        throw std::system_error(retval, std::generic_category(), "gnuplot reported an internal error");
+    }
 }
 
 /// Auxiliary function to escape a output path so it can be used for GNUplot.


### PR DESCRIPTION
There's a small tweak to the gitignore, to handle the full-power MSVS (not just VSCode), but the main point of this pull request is to handle gnuplot failures.  

Currently, if gnuplot fails (in the sense of a nonzero process return value), the failure is silent.  The return value to sciplot::runscript becomes false, but that value is never checked.  

Obviously, a gnuplot failure should be visible to calling code.  

One option is to leave sciplot::runscript as is, but check the return values in Canvas::show and Canvas::save.  If so, then sciplot::runscript should probably marked [[nodiscard]], to prevent this error from happening again.  But it's not obvious how Canvas::show and Canvas::save should handle the failure anyways.  Instead, the new code throws an exception if the gnuplot return value is nonzero.  Because any reasonable fallback is likely far (many stack frames) external to the code calling sciplot, I think this is a reasonable place for exception-based control flow.  